### PR TITLE
fix: return nil instead of error directly

### DIFF
--- a/pkg/wallet/service/eth/watchsrv/tx_creator_payment.go
+++ b/pkg/wallet/service/eth/watchsrv/tx_creator_payment.go
@@ -46,7 +46,7 @@ func (t *TxCreate) CreatePaymentTx() (string, string, error) {
 		return "", "", errors.Wrap(err, "fail to call addrRepo.GetAll(account.AccountTypeClient)")
 	}
 	if t.validateAmount(senderAddr, totalAmount) != nil {
-		return "", "", err
+		return "", "", nil
 	}
 
 	// create raw transaction each address


### PR DESCRIPTION

Return nil instead of error directly.