### PR TITLE
Fix additional linting errors (comments, naming, patterns)

### DIFF
--- a/pkg/address/xrp/hash.go
+++ b/pkg/address/xrp/hash.go
@@ -22,7 +22,7 @@ func NewRippleHash(s string) (Hash, error) {
 	}
 }
 
-// Checks hash matches expected version
+// NewRippleHashCheck checks hash matches expected version
 func NewRippleHashCheck(s string, version HashVersion) (Hash, error) {
 	hash, err := NewRippleHash(s)
 	if err != nil {
@@ -31,12 +31,12 @@ func NewRippleHashCheck(s string, version HashVersion) (Hash, error) {
 	if hash.Version() != version {
 		want := hashTypes[version].Description
 		got := hashTypes[hash.Version()].Description
-		return nil, fmt.Errorf("Bad version for: %s expected: %s got: %s ", s, want, got)
+		return nil, fmt.Errorf("bad version for: %s expected: %s got: %s ", s, want, got)
 	}
 	return hash, nil
 }
 
-func NewAccountId(b []byte) (Hash, error) {
+func NewAccountID(b []byte) (Hash, error) {
 	return newHash(b, RIPPLE_ACCOUNT_ID)
 }
 
@@ -60,8 +60,8 @@ func NewFamilySeed(b []byte) (Hash, error) {
 	return newHash(b, RIPPLE_FAMILY_SEED)
 }
 
-func AccountId(key Key, sequence *uint32) (Hash, error) {
-	return NewAccountId(key.Id(sequence))
+func AccountID(key Key, sequence *uint32) (Hash, error) {
+	return NewAccountID(key.Id(sequence))
 }
 
 func AccountPublicKey(key Key, sequence *uint32) (Hash, error) {

--- a/pkg/address/xrp/util.go
+++ b/pkg/address/xrp/util.go
@@ -9,21 +9,21 @@ import (
 
 // Write operations in a hash.Hash never return an error
 
-// Returns a SHA512 hash of the input bytes
+// Sha512 returns a SHA512 hash of the input bytes
 func Sha512(b []byte) []byte {
 	hasher := sha512.New()
 	hasher.Write(b)
 	return hasher.Sum(nil)
 }
 
-// Returns first 32 bytes of a SHA512 of the input bytes
+// Sha512Half returns first 32 bytes of a SHA512 of the input bytes
 func Sha512Half(b []byte) []byte {
 	hasher := sha512.New()
 	hasher.Write(b)
 	return hasher.Sum(nil)[:32]
 }
 
-// Returns first 16 bytes of a SHA512 of the input bytes
+// Sha512Quarter returns first 16 bytes of a SHA512 of the input bytes
 func Sha512Quarter(b []byte) []byte {
 	hasher := sha512.New()
 	hasher.Write(b)

--- a/pkg/command/keygen/api/btc/walletpassphrasechange.go
+++ b/pkg/command/keygen/api/btc/walletpassphrasechange.go
@@ -35,11 +35,11 @@ Options:
 func (c *WalletPassphraseChangeCommand) Run(args []string) int {
 	c.ui.Info(c.Synopsis())
 
-	var old, new string
+	var old, newPass string
 
 	flags := flag.NewFlagSet(c.name, flag.ContinueOnError)
 	flags.StringVar(&old, "old", "", "old passphrase")
-	flags.StringVar(&new, "new", "", "new passphrase")
+	flags.StringVar(&newPass, "new", "", "new passphrase")
 	if err := flags.Parse(args); err != nil {
 		return 1
 	}
@@ -49,12 +49,12 @@ func (c *WalletPassphraseChangeCommand) Run(args []string) int {
 		c.ui.Error("old passphrase option [-old] is required")
 		return 1
 	}
-	if new == "" {
+	if newPass == "" {
 		c.ui.Error("new passphrase option [-new] is required")
 		return 1
 	}
 
-	err := c.btc.WalletPassphraseChange(old, new)
+	err := c.btc.WalletPassphraseChange(old, newPass)
 	if err != nil {
 		c.ui.Error(fmt.Sprintf("fail to call btc.WalletPassphraseChange() %+v", err))
 		return 1

--- a/pkg/wallet/api/btcgrp/api-interface.go
+++ b/pkg/wallet/api/btcgrp/api-interface.go
@@ -108,7 +108,7 @@ type Bitcoiner interface {
 	EncryptWallet(passphrase string) error
 	WalletLock() error
 	WalletPassphrase(passphrase string, timeoutSecs int64) error
-	WalletPassphraseChange(old, new string) error
+	WalletPassphraseChange(old, newPass string) error
 	LoadWallet(fileName string) error
 	UnLoadWallet(fileName string) error
 	CreateWallet(fileName string, disablePrivKey bool) error

--- a/pkg/wallet/api/btcgrp/btc/wallet.go
+++ b/pkg/wallet/api/btcgrp/btc/wallet.go
@@ -102,8 +102,8 @@ func (b *Bitcoin) WalletPassphrase(passphrase string, timeoutSecs int64) error {
 }
 
 // WalletPassphraseChange change pass phrase
-func (b *Bitcoin) WalletPassphraseChange(old, new string) error {
-	return b.Client.WalletPassphraseChange(old, new)
+func (b *Bitcoin) WalletPassphraseChange(old, newPass string) error {
+	return b.Client.WalletPassphraseChange(old, newPass)
 }
 
 // LoadWallet import wallet dat

--- a/pkg/wallet/api/ethgrp/eth/rpc_eth_tx.go
+++ b/pkg/wallet/api/ethgrp/eth/rpc_eth_tx.go
@@ -198,11 +198,14 @@ func (e *Ethereum) GetTransactionReceipt(hashTx string) (*ResponseGetTransaction
 	select {
 	case <-ctx.Done():
 		err := ctx.Err()
-		if err == context.Canceled {
+		switch err {
+		case context.Canceled:
 			e.logger.Debug("context.Canceled for calling eth_getTransactionReceipt")
-		} else if err == context.DeadlineExceeded {
+		case context.DeadlineExceeded:
 			e.logger.Debug("context.DeadlineExceeded for calling eth_getTransactionReceipt")
-		} else if err != nil {
+		case nil:
+			// no error
+		default:
 			e.logger.Debug(err.Error())
 			return nil, err
 		}

--- a/pkg/wallet/key/hd_wallet.go
+++ b/pkg/wallet/key/hd_wallet.go
@@ -308,9 +308,9 @@ func (k *HDKey) xrpAddrs(privKey *btcec.PrivateKey) (string, string, string, err
 		return "", "", "", errors.New("pubKeyHash must be 20 bytes")
 	}
 	// address
-	address, err := xrpaddr.NewAccountId(pubKeyHash)
+	address, err := xrpaddr.NewAccountID(pubKeyHash)
 	if err != nil {
-		return "", "", "", errors.Wrap(err, "fail to call rcrypto.NewAccountId()")
+		return "", "", "", errors.Wrap(err, "fail to call rcrypto.NewAccountID()")
 	}
 	// publicKey
 	publicKey, err := xrpaddr.NewAccountPublicKey(pubKeyHash)


### PR DESCRIPTION
This commit addresses several categories of linting issues:

Comment Formatting (staticcheck ST1020, ST1005):
- Fix XRP function comments to proper godoc format
- NewRippleHashCheck, Sha512, Sha512Half, Sha512Quarter
- Fix error string capitalization ("Bad" → "bad")

Naming Conventions (predeclared, staticcheck ST1003):
- Rename parameter 'new' to 'newPass' to avoid predeclared identifier
- Rename NewAccountId → NewAccountID (proper Go naming)
- Rename AccountId → AccountID
- Update all references across interface, implementation, and usage

Code Quality (gocritic):
- Convert if-else chain to switch statement in rpc_eth_tx.go
- Improve error handling pattern for context errors

Files changed: 7
- pkg/address/xrp/hash.go
- pkg/address/xrp/util.go
- pkg/command/keygen/api/btc/walletpassphrasechange.go
- pkg/wallet/api/btcgrp/api-interface.go
- pkg/wallet/api/btcgrp/btc/wallet.go
- pkg/wallet/api/ethgrp/eth/rpc_eth_tx.go
- pkg/wallet/key/hd_wallet.go

🤖 Generated with [Claude Code](https://claude.com/claude-code)