### PR TITLE
refactor: Remove context.Context from Ethereum and Ripple struct fields

### DIFF
--- a/pkg/command/keygen/api/eth/importrawkey.go
+++ b/pkg/command/keygen/api/eth/importrawkey.go
@@ -1,6 +1,7 @@
 package eth
 
 import (
+	"context"
 	"flag"
 	"fmt"
 
@@ -54,7 +55,7 @@ func (c *ImportRawKeyCommand) Run(args []string) int {
 		return 1
 	}
 
-	addr, err := c.eth.ImportRawKey(privKey, passPhrase)
+	addr, err := c.eth.ImportRawKey(context.Background(), privKey, passPhrase)
 	if err != nil {
 		c.ui.Error(fmt.Sprintf("fail to call eth.ImportRawKey() %+v", err))
 		return 1

--- a/pkg/command/watch/api/eth/clientversion.go
+++ b/pkg/command/watch/api/eth/clientversion.go
@@ -1,6 +1,7 @@
 package eth
 
 import (
+	"context"
 	"flag"
 	"fmt"
 
@@ -37,7 +38,7 @@ func (c *ClientVersionCommand) Run(args []string) int {
 		return 1
 	}
 
-	version, err := c.eth.ClientVersion()
+	version, err := c.eth.ClientVersion(context.Background())
 	if err != nil {
 		c.ui.Error(fmt.Sprintf("fail to call eth.ClientVersion() %+v", err))
 		return 1

--- a/pkg/command/watch/api/eth/netversion.go
+++ b/pkg/command/watch/api/eth/netversion.go
@@ -1,6 +1,7 @@
 package eth
 
 import (
+	"context"
 	"flag"
 	"fmt"
 
@@ -37,7 +38,7 @@ func (c *NetVersionCommand) Run(args []string) int {
 		return 1
 	}
 
-	version, err := c.eth.NetVersion()
+	version, err := c.eth.NetVersion(context.Background())
 	if err != nil {
 		c.ui.Error(fmt.Sprintf("fail to call eth.NetVersion() %+v", err))
 		return 1

--- a/pkg/command/watch/api/eth/nodeinfo.go
+++ b/pkg/command/watch/api/eth/nodeinfo.go
@@ -1,6 +1,7 @@
 package eth
 
 import (
+	"context"
 	"flag"
 	"fmt"
 
@@ -37,7 +38,7 @@ func (c *NodeInfoCommand) Run(args []string) int {
 		return 1
 	}
 
-	peerInfo, err := c.eth.NodeInfo()
+	peerInfo, err := c.eth.NodeInfo(context.Background())
 	if err != nil {
 		c.ui.Error(fmt.Sprintf("fail to call eth.NodeInfo() %+v", err))
 		return 1

--- a/pkg/command/watch/api/eth/syncing.go
+++ b/pkg/command/watch/api/eth/syncing.go
@@ -1,6 +1,7 @@
 package eth
 
 import (
+	"context"
 	"flag"
 	"fmt"
 
@@ -37,7 +38,7 @@ func (c *SyncingCommand) Run(args []string) int {
 		return 1
 	}
 
-	syncResult, isSyncing, err := c.eth.Syncing()
+	syncResult, isSyncing, err := c.eth.Syncing(context.Background())
 	if err != nil {
 		c.ui.Error(fmt.Sprintf("fail to call eth.Syncing() %+v", err))
 		return 1

--- a/pkg/command/watch/api/xrp/sendcoin.go
+++ b/pkg/command/watch/api/xrp/sendcoin.go
@@ -1,6 +1,7 @@
 package xrp
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"strings"
@@ -65,7 +66,7 @@ func (c *SendCoinCommand) Run(args []string) int {
 		MaxLedgerVersionOffset: xrp.MaxLedgerVersionOffset,
 	}
 	c.ui.Info(fmt.Sprintf("sender: %s, receiver: %s, amount: %v", c.txData.Account, receiverAddr, amount))
-	txJSON, _, err := c.xrp.CreateRawTransaction(c.txData.Account, receiverAddr, amount, instructions)
+	txJSON, _, err := c.xrp.CreateRawTransaction(context.TODO(), c.txData.Account, receiverAddr, amount, instructions)
 	if err != nil {
 		c.ui.Error(fmt.Sprintf("fail to call xrp.CreateRawTransaction() %v", err))
 		return 1
@@ -73,14 +74,14 @@ func (c *SendCoinCommand) Run(args []string) int {
 	grok.Value(txJSON)
 
 	// SingTransaction
-	txID, txBlob, err := c.xrp.SignTransaction(txJSON, c.txData.Secret)
+	txID, txBlob, err := c.xrp.SignTransaction(context.TODO(), txJSON, c.txData.Secret)
 	if err != nil {
 		c.ui.Error(fmt.Sprintf("fail to call xrp.SignTransaction() %v", err))
 		return 1
 	}
 
 	// SendTransaction
-	sentTx, earlistLedgerVersion, err := c.xrp.SubmitTransaction(txBlob)
+	sentTx, earlistLedgerVersion, err := c.xrp.SubmitTransaction(context.TODO(), txBlob)
 	if err != nil {
 		c.ui.Error(fmt.Sprintf("fail to call xrp.SubmitTransaction() %v", err))
 		return 1
@@ -93,14 +94,14 @@ func (c *SendCoinCommand) Run(args []string) int {
 	}
 
 	// validate transaction
-	_, err = c.xrp.WaitValidation(sentTx.TxJSON.LastLedgerSequence)
+	_, err = c.xrp.WaitValidation(context.TODO(), sentTx.TxJSON.LastLedgerSequence)
 	if err != nil {
 		c.ui.Error(fmt.Sprintf("fail to call xrp.WaitValidation() %v", err))
 		return 1
 	}
 
 	// get transaction info
-	txInfo, err := c.xrp.GetTransaction(txID, earlistLedgerVersion)
+	txInfo, err := c.xrp.GetTransaction(context.TODO(), txID, earlistLedgerVersion)
 	if err != nil {
 		c.ui.Error(fmt.Sprintf("fail to call xrp.GetTransaction() %v", err))
 		return 1
@@ -108,7 +109,7 @@ func (c *SendCoinCommand) Run(args []string) int {
 	c.ui.Info(fmt.Sprintf("transaction Info: %v", txInfo))
 
 	// get receiver info
-	accountInfo, err := c.xrp.GetAccountInfo(receiverAddr)
+	accountInfo, err := c.xrp.GetAccountInfo(context.TODO(), receiverAddr)
 	if err != nil {
 		errStatus, _ := status.FromError(err)
 		c.ui.Error(fmt.Sprintf(

--- a/pkg/wallet/api/ethgrp/api-interface.go
+++ b/pkg/wallet/api/ethgrp/api-interface.go
@@ -1,6 +1,7 @@
 package ethgrp
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"math/big"
 
@@ -20,10 +21,10 @@ import (
 // Ethereumer Ethereum Interface
 type Ethereumer interface {
 	// balance
-	GetTotalBalance(addrs []string) (*big.Int, []eth.UserAmount)
+	GetTotalBalance(ctx context.Context, addrs []string) (*big.Int, []eth.UserAmount)
 	// client
-	BalanceAt(hexAddr string) (*big.Int, error)
-	SendRawTx(tx *types.Transaction) error
+	BalanceAt(ctx context.Context, hexAddr string) (*big.Int, error)
+	SendRawTx(ctx context.Context, tx *types.Transaction) error
 	// ethereum
 	Close()
 	CoinTypeCode() coin.CoinTypeCode
@@ -34,61 +35,61 @@ type Ethereumer interface {
 	GetPrivKey(hexAddr, password string) (*keystore.Key, error)
 	RenameParityKeyFile(hexAddr string, accountType account.AccountType) error
 	// rpc_admin
-	AddPeer(nodeURL string) error
-	AdminDataDir() (string, error)
-	NodeInfo() (*p2p.NodeInfo, error)
-	AdminPeers() ([]*p2p.PeerInfo, error)
+	AddPeer(ctx context.Context, nodeURL string) error
+	AdminDataDir(ctx context.Context) (string, error)
+	NodeInfo(ctx context.Context) (*p2p.NodeInfo, error)
+	AdminPeers(ctx context.Context) ([]*p2p.PeerInfo, error)
 	// rpc_eth
-	Syncing() (*eth.ResponseSyncing, bool, error)
-	ProtocolVersion() (uint64, error)
-	Coinbase() (string, error)
-	Accounts() ([]string, error)
-	BlockNumber() (*big.Int, error)
-	EnsureBlockNumber(loopCount int) (*big.Int, error)
-	GetBalance(hexAddr string, quantityTag eth.QuantityTag) (*big.Int, error)
-	// GetStoreageAt(hexAddr string, quantityTag eth.QuantityTag) (string, error)
-	GetTransactionCount(hexAddr string, quantityTag eth.QuantityTag) (*big.Int, error)
-	// GetBlockTransactionCountByBlockHash(blockHash string) (*big.Int, error)
-	GetBlockTransactionCountByNumber(blockNumber uint64) (*big.Int, error)
-	// GetUncleCountByBlockHash(blockHash string) (*big.Int, error)
-	GetUncleCountByBlockNumber(blockNumber uint64) (*big.Int, error)
-	// GetCode(hexAddr string, quantityTag eth.QuantityTag) (*big.Int, error)
-	GetBlockByNumber(blockNumber uint64) (*eth.BlockInfo, error)
+	Syncing(ctx context.Context) (*eth.ResponseSyncing, bool, error)
+	ProtocolVersion(ctx context.Context) (uint64, error)
+	Coinbase(ctx context.Context) (string, error)
+	Accounts(ctx context.Context) ([]string, error)
+	BlockNumber(ctx context.Context) (*big.Int, error)
+	EnsureBlockNumber(ctx context.Context, loopCount int) (*big.Int, error)
+	GetBalance(ctx context.Context, hexAddr string, quantityTag eth.QuantityTag) (*big.Int, error)
+	// GetStoreageAt(ctx context.Context, hexAddr string, quantityTag eth.QuantityTag) (string, error)
+	GetTransactionCount(ctx context.Context, hexAddr string, quantityTag eth.QuantityTag) (*big.Int, error)
+	// GetBlockTransactionCountByBlockHash(ctx context.Context, blockHash string) (*big.Int, error)
+	GetBlockTransactionCountByNumber(ctx context.Context, blockNumber uint64) (*big.Int, error)
+	// GetUncleCountByBlockHash(ctx context.Context, blockHash string) (*big.Int, error)
+	GetUncleCountByBlockNumber(ctx context.Context, blockNumber uint64) (*big.Int, error)
+	// GetCode(ctx context.Context, hexAddr string, quantityTag eth.QuantityTag) (*big.Int, error)
+	GetBlockByNumber(ctx context.Context, blockNumber uint64) (*eth.BlockInfo, error)
 	// rpc_eth_gas
-	GasPrice() (*big.Int, error)
-	EstimateGas(msg *ethereum.CallMsg) (*big.Int, error)
+	GasPrice(ctx context.Context) (*big.Int, error)
+	EstimateGas(ctx context.Context, msg *ethereum.CallMsg) (*big.Int, error)
 	// rpc_eth_tx
-	Sign(hexAddr, message string) (string, error)
-	SendTransaction(msg *ethereum.CallMsg) (string, error)
-	SendRawTransaction(signedTx string) (string, error)
-	SendRawTransactionWithTypesTx(tx *types.Transaction) (string, error)
-	GetTransactionByHash(hashTx string) (*eth.ResponseGetTransaction, error)
-	GetTransactionReceipt(hashTx string) (*eth.ResponseGetTransactionReceipt, error)
+	Sign(ctx context.Context, hexAddr, message string) (string, error)
+	SendTransaction(ctx context.Context, msg *ethereum.CallMsg) (string, error)
+	SendRawTransaction(ctx context.Context, signedTx string) (string, error)
+	SendRawTransactionWithTypesTx(ctx context.Context, tx *types.Transaction) (string, error)
+	GetTransactionByHash(ctx context.Context, hashTx string) (*eth.ResponseGetTransaction, error)
+	GetTransactionReceipt(ctx context.Context, hashTx string) (*eth.ResponseGetTransactionReceipt, error)
 	// rpc_miner
-	StartMining() error
-	StopMining() error
-	Mining() (bool, error)
-	HashRate() (*big.Int, error)
+	StartMining(ctx context.Context) error
+	StopMining(ctx context.Context) error
+	Mining(ctx context.Context) (bool, error)
+	HashRate(ctx context.Context) (*big.Int, error)
 	// rpc_net
-	NetVersion() (uint16, error)
-	NetListening() (bool, error)
-	NetPeerCount() (*big.Int, error)
+	NetVersion(ctx context.Context) (uint16, error)
+	NetListening(ctx context.Context) (bool, error)
+	NetPeerCount(ctx context.Context) (*big.Int, error)
 	// rpc_personal
-	ImportRawKey(hexKey, passPhrase string) (string, error)
-	ListAccounts() ([]string, error)
-	NewAccount(passphrase string, accountType account.AccountType) (string, error)
-	LockAccount(hexAddr string) error
-	UnlockAccount(hexAddr, passphrase string, duration uint64) (bool, error)
+	ImportRawKey(ctx context.Context, hexKey, passPhrase string) (string, error)
+	ListAccounts(ctx context.Context) ([]string, error)
+	NewAccount(ctx context.Context, passphrase string, accountType account.AccountType) (string, error)
+	LockAccount(ctx context.Context, hexAddr string) error
+	UnlockAccount(ctx context.Context, hexAddr, passphrase string, duration uint64) (bool, error)
 	// rpc_web3
-	ClientVersion() (string, error)
-	SHA3(data string) (string, error)
+	ClientVersion(ctx context.Context) (string, error)
+	SHA3(ctx context.Context, data string) (string, error)
 	// transaction
 	CreateRawTransaction(
-		fromAddr, toAddr string, amount uint64, additionalNonce int,
+		ctx context.Context, fromAddr, toAddr string, amount uint64, additionalNonce int,
 	) (*ethtx.RawTx, *models.EthDetailTX, error)
 	SignOnRawTransaction(rawTx *ethtx.RawTx, passphrase string) (*ethtx.RawTx, error)
-	SendSignedRawTransaction(signedTxHex string) (string, error)
-	GetConfirmation(hashTx string) (uint64, error)
+	SendSignedRawTransaction(ctx context.Context, signedTxHex string) (string, error)
+	GetConfirmation(ctx context.Context, hashTx string) (uint64, error)
 	// util
 	DecodeBig(input string) (*big.Int, error)
 	ValidateAddr(addr string) error
@@ -103,9 +104,9 @@ type Ethereumer interface {
 type ERC20er interface {
 	ValidateAddr(addr string) error
 	FloatToBigInt(v float64) *big.Int
-	GetBalance(hexAddr string, quantityTag eth.QuantityTag) (*big.Int, error)
+	GetBalance(ctx context.Context, hexAddr string, quantityTag eth.QuantityTag) (*big.Int, error)
 	CreateRawTransaction(
-		fromAddr, toAddr string, amount uint64, additionalNonce int,
+		ctx context.Context, fromAddr, toAddr string, amount uint64, additionalNonce int,
 	) (*ethtx.RawTx, *models.EthDetailTX, error)
 }
 
@@ -113,6 +114,6 @@ type ERC20er interface {
 type EtherTxCreator = ERC20er
 
 type EtherTxMonitor interface {
-	GetTotalBalance(addrs []string) (*big.Int, []eth.UserAmount)
-	GetConfirmation(hashTx string) (uint64, error)
+	GetTotalBalance(ctx context.Context, addrs []string) (*big.Int, []eth.UserAmount)
+	GetConfirmation(ctx context.Context, hashTx string) (uint64, error)
 }

--- a/pkg/wallet/api/ethgrp/eth/balance.go
+++ b/pkg/wallet/api/ethgrp/eth/balance.go
@@ -1,6 +1,7 @@
 package eth
 
 import (
+	"context"
 	"math/big"
 )
 
@@ -11,11 +12,11 @@ type UserAmount struct {
 }
 
 // GetTotalBalance returns total amount and addresses
-func (e *Ethereum) GetTotalBalance(addrs []string) (*big.Int, []UserAmount) {
+func (e *Ethereum) GetTotalBalance(ctx context.Context, addrs []string) (*big.Int, []UserAmount) {
 	total := new(big.Int)
 	userAmounts := make([]UserAmount, 0, len(addrs))
 	for _, addr := range addrs {
-		balance, err := e.GetBalance(addr, QuantityTagPending)
+		balance, err := e.GetBalance(ctx, addr, QuantityTagPending)
 		if err != nil {
 			continue
 		}

--- a/pkg/wallet/api/ethgrp/eth/client.go
+++ b/pkg/wallet/api/ethgrp/eth/client.go
@@ -1,6 +1,7 @@
 package eth
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math/big"
@@ -11,9 +12,9 @@ import (
 
 // BalanceAt returns balance of address
 // if wrong address is given, response of balance would be strange like `416778046407207737`
-func (e *Ethereum) BalanceAt(hexAddr string) (*big.Int, error) {
+func (e *Ethereum) BalanceAt(ctx context.Context, hexAddr string) (*big.Int, error) {
 	account := common.HexToAddress(hexAddr)
-	balance, err := e.ethClient.BalanceAt(e.ctx, account, nil)
+	balance, err := e.ethClient.BalanceAt(ctx, account, nil)
 	if err != nil {
 		return nil, fmt.Errorf("fail to call ethClient.BalanceAt(): %w", err)
 	}
@@ -24,6 +25,6 @@ func (e *Ethereum) BalanceAt(hexAddr string) (*big.Int, error) {
 }
 
 // SendRawTx sends raw transaction
-func (e *Ethereum) SendRawTx(tx *types.Transaction) error {
-	return e.ethClient.SendTransaction(e.ctx, tx)
+func (e *Ethereum) SendRawTx(ctx context.Context, tx *types.Transaction) error {
+	return e.ethClient.SendTransaction(ctx, tx)
 }

--- a/pkg/wallet/api/ethgrp/eth/ethereum.go
+++ b/pkg/wallet/api/ethgrp/eth/ethereum.go
@@ -21,7 +21,6 @@ type Ethereum struct {
 	rpcClient    *ethrpc.Client
 	chainConf    *chaincfg.Params
 	coinTypeCode coin.CoinTypeCode
-	ctx          context.Context
 	uuidHandler  uuid.UUIDHandler
 	netID        uint16
 	version      string
@@ -43,13 +42,12 @@ func NewEthereum(
 		rpcClient:    rpcClient,
 		coinTypeCode: coinTypeCode,
 		uuidHandler:  uuidHandler,
-		ctx:          ctx,
 		keyDir:       conf.KeyDirName,
 	}
 
 	// key dir
 	if eth.keyDir == "" {
-		dirName, err := eth.AdminDataDir()
+		dirName, err := eth.AdminDataDir(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("fail to call eth.AdminDataDir(): %w", err)
 		}
@@ -58,7 +56,7 @@ func NewEthereum(
 	logger.Debug("eth.keyDir", "eth.keyDir", eth.keyDir)
 
 	// get NetID
-	netID, err := eth.NetVersion()
+	netID, err := eth.NetVersion(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("fail to call eth.NetVersion(): %w", err)
 	}
@@ -71,7 +69,7 @@ func NewEthereum(
 	}
 
 	// get client version
-	clientVer, err := eth.ClientVersion()
+	clientVer, err := eth.ClientVersion(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("fail to call eth.ClientVersion(): %w", err)
 	}
@@ -80,7 +78,7 @@ func NewEthereum(
 	eth.isParity = isParity(clientVer)
 
 	// check sync progress
-	res, isSyncing, err := eth.Syncing()
+	res, isSyncing, err := eth.Syncing(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("fail to call eth.Syncing(): %w", err)
 	}
@@ -96,7 +94,7 @@ func NewEthereum(
 	}
 
 	// check network connections
-	isListening, err := eth.NetListening()
+	isListening, err := eth.NetListening(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("fail to call eth.NetListening(): %w", err)
 	}

--- a/pkg/wallet/api/ethgrp/eth/rpc_admin.go
+++ b/pkg/wallet/api/ethgrp/eth/rpc_admin.go
@@ -1,6 +1,7 @@
 package eth
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/p2p"
@@ -8,11 +9,11 @@ import (
 
 // AddPeer requests adding a new remote node to the list of tracked static nodes
 // https://github.com/ethereum/go-ethereum/wiki/Management-APIs#admin_addpeer
-func (e *Ethereum) AddPeer(nodeURL string) error {
+func (e *Ethereum) AddPeer(ctx context.Context, nodeURL string) error {
 	var bRet bool
 	// TODO: Result needs to be verified
 	// The response data type are bytes, but it cannot parse...
-	err := e.rpcClient.CallContext(e.ctx, &bRet, "admin_addPeer", nodeURL)
+	err := e.rpcClient.CallContext(ctx, &bRet, "admin_addPeer", nodeURL)
 	if err != nil {
 		return err
 	}
@@ -21,13 +22,13 @@ func (e *Ethereum) AddPeer(nodeURL string) error {
 
 // AdminDataDir returns the absolute path the running Geth node currently uses to store all its databases
 // returns like ${HOME}/Library/Ethereum/goerli
-func (e *Ethereum) AdminDataDir() (string, error) {
+func (e *Ethereum) AdminDataDir(ctx context.Context) (string, error) {
 	if e.isParity {
 		return "", nil
 	}
 
 	var dataDir string
-	err := e.rpcClient.CallContext(e.ctx, &dataDir, "admin_datadir")
+	err := e.rpcClient.CallContext(ctx, &dataDir, "admin_datadir")
 	if err != nil {
 		return "", fmt.Errorf("fail to call rpc.CallContext(admin_datadir): %w", err)
 	}
@@ -35,9 +36,9 @@ func (e *Ethereum) AdminDataDir() (string, error) {
 }
 
 // NodeInfo gathers and returns a collection of metadata known about the host.
-func (e *Ethereum) NodeInfo() (*p2p.NodeInfo, error) {
+func (e *Ethereum) NodeInfo(ctx context.Context) (*p2p.NodeInfo, error) {
 	var r *p2p.NodeInfo
-	err := e.rpcClient.CallContext(e.ctx, &r, "admin_nodeInfo")
+	err := e.rpcClient.CallContext(ctx, &r, "admin_nodeInfo")
 	if err != nil {
 		return nil, err
 	}
@@ -45,13 +46,13 @@ func (e *Ethereum) NodeInfo() (*p2p.NodeInfo, error) {
 }
 
 // AdminPeers returns all the information known about the connected remote nodes at the networking granularity.
-func (e *Ethereum) AdminPeers() ([]*p2p.PeerInfo, error) {
+func (e *Ethereum) AdminPeers(ctx context.Context) ([]*p2p.PeerInfo, error) {
 	if e.isParity {
 		return nil, nil
 	}
 
 	var peerInfo []*p2p.PeerInfo
-	err := e.rpcClient.CallContext(e.ctx, &peerInfo, "admin_peers")
+	err := e.rpcClient.CallContext(ctx, &peerInfo, "admin_peers")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/wallet/api/ethgrp/eth/rpc_eth_gas.go
+++ b/pkg/wallet/api/ethgrp/eth/rpc_eth_gas.go
@@ -1,6 +1,7 @@
 package eth
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 
@@ -11,9 +12,9 @@ import (
 // GasPrice returns the current price per gas in wei
 // https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_gasprice
 // - returns like `1000000000`
-func (e *Ethereum) GasPrice() (*big.Int, error) {
+func (e *Ethereum) GasPrice(ctx context.Context) (*big.Int, error) {
 	var gasPrice string
-	err := e.rpcClient.CallContext(e.ctx, &gasPrice, "eth_gasPrice")
+	err := e.rpcClient.CallContext(ctx, &gasPrice, "eth_gasPrice")
 	if err != nil {
 		return nil, fmt.Errorf("fail to call rpc.CallContext(eth_gasPrice): %w", err)
 	}
@@ -29,9 +30,9 @@ func (e *Ethereum) GasPrice() (*big.Int, error) {
 // https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_estimategas
 //
 //	is this value GasLimit??
-func (e *Ethereum) EstimateGas(msg *ethereum.CallMsg) (*big.Int, error) {
+func (e *Ethereum) EstimateGas(ctx context.Context, msg *ethereum.CallMsg) (*big.Int, error) {
 	var estimated string
-	err := e.rpcClient.CallContext(e.ctx, &estimated, "eth_estimateGas", toCallArg(msg))
+	err := e.rpcClient.CallContext(ctx, &estimated, "eth_estimateGas", toCallArg(msg))
 	if err != nil {
 		// Invalid params: Invalid bytes format. Expected a 0x-prefixed hex string with even length.
 		return nil, fmt.Errorf("fail to call rpc.CallContext(eth_estimateGas): %w", err)

--- a/pkg/wallet/api/ethgrp/eth/rpc_miner.go
+++ b/pkg/wallet/api/ethgrp/eth/rpc_miner.go
@@ -1,6 +1,7 @@
 package eth
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math/big"
@@ -8,10 +9,10 @@ import (
 
 // StartMining starts the CPU mining process with the given number of threads and generate a new DAG if need be
 // https://github.com/ethereum/go-ethereum/wiki/Management-APIs#miner_start
-func (e *Ethereum) StartMining() error {
+func (e *Ethereum) StartMining(ctx context.Context) error {
 	var r []byte
 	// TODO: Result needs to be verified
-	err := e.rpcClient.CallContext(e.ctx, &r, "miner_start")
+	err := e.rpcClient.CallContext(ctx, &r, "miner_start")
 	if err != nil {
 		return fmt.Errorf("fail to call rpc.CallContext(miner_start): %w", err)
 	}
@@ -20,8 +21,8 @@ func (e *Ethereum) StartMining() error {
 
 // StopMining stops the CPU mining operation
 // https://github.com/ethereum/go-ethereum/wiki/Management-APIs#miner_stop
-func (e *Ethereum) StopMining() error {
-	err := e.rpcClient.CallContext(e.ctx, nil, "miner_stop")
+func (e *Ethereum) StopMining(ctx context.Context) error {
+	err := e.rpcClient.CallContext(ctx, nil, "miner_stop")
 	if err != nil {
 		return errors.New("fail to call rpc.CallContext(miner_start)")
 	}
@@ -30,9 +31,9 @@ func (e *Ethereum) StopMining() error {
 
 // Mining returns true if client is actively mining new blocks
 // https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_mining
-func (e *Ethereum) Mining() (bool, error) {
+func (e *Ethereum) Mining(ctx context.Context) (bool, error) {
 	var bRet bool
-	err := e.rpcClient.CallContext(e.ctx, &bRet, "eth_mining")
+	err := e.rpcClient.CallContext(ctx, &bRet, "eth_mining")
 	if err != nil {
 		return false, errors.New("fail to call rpc.CallContext(eth_mining)")
 	}
@@ -41,9 +42,9 @@ func (e *Ethereum) Mining() (bool, error) {
 
 // HashRate returns the number of hashes per second that the node is mining with
 // https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_hashrate
-func (e *Ethereum) HashRate() (*big.Int, error) {
+func (e *Ethereum) HashRate(ctx context.Context) (*big.Int, error) {
 	var hashCount string
-	err := e.rpcClient.CallContext(e.ctx, &hashCount, "eth_hashrate")
+	err := e.rpcClient.CallContext(ctx, &hashCount, "eth_hashrate")
 	if err != nil {
 		return nil, fmt.Errorf("fail to call rpc.CallContext(eth_hashrate): %w", err)
 	}

--- a/pkg/wallet/api/ethgrp/eth/rpc_net.go
+++ b/pkg/wallet/api/ethgrp/eth/rpc_net.go
@@ -1,6 +1,7 @@
 package eth
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"strconv"
@@ -15,9 +16,9 @@ import (
 // "4": Rinkeby Testnet
 // "5": Goerli Testnet
 // "42": Kovan Testnet
-func (e *Ethereum) NetVersion() (uint16, error) {
+func (e *Ethereum) NetVersion(ctx context.Context) (uint16, error) {
 	var resNetVersion string
-	err := e.rpcClient.CallContext(e.ctx, &resNetVersion, "net_version")
+	err := e.rpcClient.CallContext(ctx, &resNetVersion, "net_version")
 	if err != nil {
 		return 0, fmt.Errorf("fail to call client.CallContext(net_version): %w", err)
 	}
@@ -32,9 +33,9 @@ func (e *Ethereum) NetVersion() (uint16, error) {
 // NetListening returns true if client is actively listening for network connections
 // https://github.com/ethereum/wiki/wiki/JSON-RPC#net_listening
 // - if response is false, watch wallet should not be used
-func (e *Ethereum) NetListening() (bool, error) {
+func (e *Ethereum) NetListening(ctx context.Context) (bool, error) {
 	var isConnected bool
-	err := e.rpcClient.CallContext(e.ctx, &isConnected, "net_listening")
+	err := e.rpcClient.CallContext(ctx, &isConnected, "net_listening")
 	if err != nil {
 		return false, fmt.Errorf("fail to call rpc.CallContext(net_listening): %w", err)
 	}
@@ -44,9 +45,9 @@ func (e *Ethereum) NetListening() (bool, error) {
 
 // NetPeerCount returns number of peers currently connected to the client
 // https://github.com/ethereum/wiki/wiki/JSON-RPC#net_peercount
-func (e *Ethereum) NetPeerCount() (*big.Int, error) {
+func (e *Ethereum) NetPeerCount(ctx context.Context) (*big.Int, error) {
 	var resPeerNumber string
-	err := e.rpcClient.CallContext(e.ctx, &resPeerNumber, "net_peerCount")
+	err := e.rpcClient.CallContext(ctx, &resPeerNumber, "net_peerCount")
 	if err != nil {
 		return nil, fmt.Errorf("fail to call client.CallContext(net_peerCount): %w", err)
 	}

--- a/pkg/wallet/api/ethgrp/eth/rpc_personal.go
+++ b/pkg/wallet/api/ethgrp/eth/rpc_personal.go
@@ -1,6 +1,7 @@
 package eth
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -15,13 +16,13 @@ import (
 //
 // https://github.com/ethereum/go-ethereum/wiki/Management-APIs#personal_importrawkey
 // - private key is stored and read from node server
-func (e *Ethereum) ImportRawKey(hexKey, passPhrase string) (string, error) {
+func (e *Ethereum) ImportRawKey(ctx context.Context, hexKey, passPhrase string) (string, error) {
 	if strings.HasPrefix(hexKey, "0x") {
 		hexKey = strings.TrimLeft(hexKey, "0x")
 	}
 
 	var address string
-	err := e.rpcClient.CallContext(e.ctx, &address, "personal_importRawKey", hexKey, passPhrase)
+	err := e.rpcClient.CallContext(ctx, &address, "personal_importRawKey", hexKey, passPhrase)
 	if err != nil {
 		if strings.Contains(err.Error(), "account already exists") {
 			logger.Warn(err.Error())
@@ -37,9 +38,9 @@ func (e *Ethereum) ImportRawKey(hexKey, passPhrase string) (string, error) {
 // https://github.com/ethereum/go-ethereum/wiki/Management-APIs#personal_listaccounts
 // - private key is stored and read from node server
 // - result is same as Accounts()
-func (e *Ethereum) ListAccounts() ([]string, error) {
+func (e *Ethereum) ListAccounts(ctx context.Context) ([]string, error) {
 	var accounts []string
-	err := e.rpcClient.CallContext(e.ctx, &accounts, "personal_listAccounts")
+	err := e.rpcClient.CallContext(ctx, &accounts, "personal_listAccounts")
 	if err != nil {
 		return nil, fmt.Errorf("fail to call rpc.CallContext(personal_listAccounts): %w", err)
 	}
@@ -50,9 +51,9 @@ func (e *Ethereum) ListAccounts() ([]string, error) {
 // NewAccount generates a new private key and stores it in the key store directory
 // https://github.com/ethereum/go-ethereum/wiki/Management-APIs#personal_newaccount
 // - private key is stored and read from node server
-func (e *Ethereum) NewAccount(passphrase string, accountType account.AccountType) (string, error) {
+func (e *Ethereum) NewAccount(ctx context.Context, passphrase string, accountType account.AccountType) (string, error) {
 	var address string
-	err := e.rpcClient.CallContext(e.ctx, &address, "personal_newAccount", passphrase)
+	err := e.rpcClient.CallContext(ctx, &address, "personal_newAccount", passphrase)
 	if err != nil {
 		return "", fmt.Errorf("fail to call rpc.CallContext(personal_newAccount): %w", err)
 	}
@@ -68,8 +69,8 @@ func (e *Ethereum) NewAccount(passphrase string, accountType account.AccountType
 
 // LockAccount removes the private key with given address from memory
 // https://github.com/ethereum/go-ethereum/wiki/Management-APIs#personal_lockaccount
-func (e *Ethereum) LockAccount(hexAddr string) error {
-	err := e.rpcClient.CallContext(e.ctx, nil, "personal_lockAccount", hexAddr)
+func (e *Ethereum) LockAccount(ctx context.Context, hexAddr string) error {
+	err := e.rpcClient.CallContext(ctx, nil, "personal_lockAccount", hexAddr)
 	if err != nil {
 		return fmt.Errorf("fail to call rpc.CallContext(personal_lockAccount): %w", err)
 	}
@@ -83,12 +84,12 @@ func (e *Ethereum) LockAccount(hexAddr string) error {
 // https://github.com/ethereum/go-ethereum/wiki/Management-APIs#personal_unlockaccount
 // FIXME: how to fix error `account unlock with HTTP access is forbidden`
 // - --allow-insecure-unlock option is required to run geth
-func (e *Ethereum) UnlockAccount(hexAddr, passphrase string, duration uint64) (bool, error) {
+func (e *Ethereum) UnlockAccount(ctx context.Context, hexAddr, passphrase string, duration uint64) (bool, error) {
 	// eoncode duration
 	// encodedDuration := hexutil.EncodeUint64(duration)
 
 	var ret bool
-	err := e.rpcClient.CallContext(e.ctx, &ret, "personal_unlockAccount", hexAddr, passphrase, duration)
+	err := e.rpcClient.CallContext(ctx, &ret, "personal_unlockAccount", hexAddr, passphrase, duration)
 	if err != nil {
 		return false, fmt.Errorf("fail to call rpc.CallContext(personal_unlockAccount): %w", err)
 	}

--- a/pkg/wallet/api/ethgrp/eth/rpc_web3.go
+++ b/pkg/wallet/api/ethgrp/eth/rpc_web3.go
@@ -1,6 +1,7 @@
 package eth
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -8,9 +9,9 @@ import (
 // https://github.com/ethereum/wiki/wiki/JSON-RPC#web3_clientversion
 //   - returns like `Geth/v1.9.14-stable/darwin-amd64/go1.14.2`
 //     `Parity-Ethereum//v2.7.2-stable-d961010f63-20200205/x86_64-apple-darwin/rustc1.41.0`
-func (e *Ethereum) ClientVersion() (string, error) {
+func (e *Ethereum) ClientVersion(ctx context.Context) (string, error) {
 	var resClientVersion string
-	err := e.rpcClient.CallContext(e.ctx, &resClientVersion, "web3_clientVersion")
+	err := e.rpcClient.CallContext(ctx, &resClientVersion, "web3_clientVersion")
 	if err != nil {
 		return "", fmt.Errorf("fail to call client.CallContext(web3_clientVersion): %w", err)
 	}
@@ -19,9 +20,9 @@ func (e *Ethereum) ClientVersion() (string, error) {
 
 // SHA3 returns Keccak-256 (not the standardized SHA3-256) of the given data
 // https://github.com/ethereum/wiki/wiki/JSON-RPC#web3_sha3
-func (e *Ethereum) SHA3(data string) (string, error) {
+func (e *Ethereum) SHA3(ctx context.Context, data string) (string, error) {
 	var res string
-	err := e.rpcClient.CallContext(e.ctx, &res, "web3_sha3", data)
+	err := e.rpcClient.CallContext(ctx, &res, "web3_sha3", data)
 	if err != nil {
 		return "", fmt.Errorf("fail to call client.CallContext(web3_sha3): %w", err)
 	}

--- a/pkg/wallet/api/xrpgrp/api-interface.go
+++ b/pkg/wallet/api/xrpgrp/api-interface.go
@@ -1,6 +1,8 @@
 package xrpgrp
 
 import (
+	"context"
+
 	"github.com/btcsuite/btcd/chaincfg"
 
 	"github.com/hiromaily/go-crypto-wallet/pkg/wallet/api/xrpgrp/xrp"
@@ -14,12 +16,12 @@ type Rippler interface {
 	RippleAPIer
 
 	// balance
-	GetBalance(addr string) (float64, error)
-	GetTotalBalance(addrs []string) float64
+	GetBalance(ctx context.Context, addr string) (float64, error)
+	GetTotalBalance(ctx context.Context, addrs []string) float64
 
 	// transaction
 	CreateRawTransaction(
-		senderAccount, receiverAccount string, amount float64, instructions *xrp.Instructions,
+		ctx context.Context, senderAccount, receiverAccount string, amount float64, instructions *xrp.Instructions,
 	) (*xrp.TxInput, string, error)
 
 	// ripple
@@ -31,35 +33,35 @@ type Rippler interface {
 // RippleAPIer is RippleAPI interface
 type RippleAPIer interface {
 	// RippleAccountAPI
-	GetAccountInfo(address string) (*xrp.ResponseGetAccountInfo, error)
+	GetAccountInfo(ctx context.Context, address string) (*xrp.ResponseGetAccountInfo, error)
 	// RippleAddressAPI
-	GenerateAddress() (*xrp.ResponseGenerateAddress, error)
-	GenerateXAddress() (*xrp.ResponseGenerateXAddress, error)
-	IsValidAddress(addr string) (bool, error)
+	GenerateAddress(ctx context.Context) (*xrp.ResponseGenerateAddress, error)
+	GenerateXAddress(ctx context.Context) (*xrp.ResponseGenerateXAddress, error)
+	IsValidAddress(ctx context.Context, addr string) (bool, error)
 	// RippleTxAPI
 	PrepareTransaction(
-		senderAccount, receiverAccount string, amount float64, instructions *xrp.Instructions,
+		ctx context.Context, senderAccount, receiverAccount string, amount float64, instructions *xrp.Instructions,
 	) (*xrp.TxInput, string, error)
-	SignTransaction(txJSON *xrp.TxInput, secret string) (string, string, error)
-	CombineTransaction(signedTxs []string) (string, string, error)
-	SubmitTransaction(signedTx string) (*xrp.SentTx, uint64, error)
-	WaitValidation(targetledgerVarsion uint64) (uint64, error)
-	GetTransaction(txID string, targetLedgerVersion uint64) (*xrp.TxInfo, error)
+	SignTransaction(ctx context.Context, txJSON *xrp.TxInput, secret string) (string, string, error)
+	CombineTransaction(ctx context.Context, signedTxs []string) (string, string, error)
+	SubmitTransaction(ctx context.Context, signedTx string) (*xrp.SentTx, uint64, error)
+	WaitValidation(ctx context.Context, targetledgerVarsion uint64) (uint64, error)
+	GetTransaction(ctx context.Context, txID string, targetLedgerVersion uint64) (*xrp.TxInfo, error)
 }
 
 // RipplePublicer is RipplePublic interface
 type RipplePublicer interface {
 	// public_account
-	AccountChannels(sender, receiver string) (*xrp.ResponseAccountChannels, error)
-	AccountInfo(address string) (*xrp.ResponseAccountInfo, error)
+	AccountChannels(ctx context.Context, sender, receiver string) (*xrp.ResponseAccountChannels, error)
+	AccountInfo(ctx context.Context, address string) (*xrp.ResponseAccountInfo, error)
 	// public_server_info
-	ServerInfo() (*xrp.ResponseServerInfo, error)
+	ServerInfo(ctx context.Context) (*xrp.ResponseServerInfo, error)
 }
 
 // RippleAdminer is RippleAdmin interface
 type RippleAdminer interface {
 	// admin_keygen
-	ValidationCreate(secret string) (*xrp.ResponseValidationCreate, error)
-	WalletProposeWithKey(seed string, keyType xrp.XRPKeyType) (*xrp.ResponseWalletPropose, error)
-	WalletPropose(passphrase string) (*xrp.ResponseWalletPropose, error)
+	ValidationCreate(ctx context.Context, secret string) (*xrp.ResponseValidationCreate, error)
+	WalletProposeWithKey(ctx context.Context, seed string, keyType xrp.XRPKeyType) (*xrp.ResponseWalletPropose, error)
+	WalletPropose(ctx context.Context, passphrase string) (*xrp.ResponseWalletPropose, error)
 }

--- a/pkg/wallet/api/xrpgrp/xrp/admin_keygen.go
+++ b/pkg/wallet/api/xrpgrp/xrp/admin_keygen.go
@@ -33,7 +33,7 @@ type ResponseValidationCreate struct {
 }
 
 // ValidationCreate calls validation_create method
-func (r *Ripple) ValidationCreate(secret string) (*ResponseValidationCreate, error) {
+func (r *Ripple) ValidationCreate(ctx context.Context, secret string) (*ResponseValidationCreate, error) {
 	if r.wsAdmin == nil {
 		return nil, XRPErrorDisabledAdminAPI
 	}
@@ -44,7 +44,7 @@ func (r *Ripple) ValidationCreate(secret string) (*ResponseValidationCreate, err
 		Secret:  secret,
 	}
 	var res ResponseValidationCreate
-	if err := r.wsAdmin.Call(context.Background(), &req, &res); err != nil {
+	if err := r.wsAdmin.Call(ctx, &req, &res); err != nil {
 		return nil, fmt.Errorf("fail to call wsAdmin.Call(validation_create): %w", err)
 	}
 	return &res, nil
@@ -81,7 +81,9 @@ type ResponseWalletPropose struct {
 }
 
 // WalletProposeWithKey calls wallet_propose method
-func (r *Ripple) WalletProposeWithKey(seed string, keyType XRPKeyType) (*ResponseWalletPropose, error) {
+func (r *Ripple) WalletProposeWithKey(
+	ctx context.Context, seed string, keyType XRPKeyType,
+) (*ResponseWalletPropose, error) {
 	if r.wsAdmin == nil {
 		return nil, XRPErrorDisabledAdminAPI
 	}
@@ -92,7 +94,7 @@ func (r *Ripple) WalletProposeWithKey(seed string, keyType XRPKeyType) (*Respons
 		KeyType: keyType.String(),
 	}
 	var res ResponseWalletPropose
-	if err := r.wsAdmin.Call(context.Background(), &req, &res); err != nil {
+	if err := r.wsAdmin.Call(ctx, &req, &res); err != nil {
 		return nil, fmt.Errorf("fail to call wsAdmin.Call(wallet_propose): %w", err)
 	}
 	return &res, nil
@@ -100,7 +102,7 @@ func (r *Ripple) WalletProposeWithKey(seed string, keyType XRPKeyType) (*Respons
 
 // WalletPropose calls wallet_propose method
 // - result is same as long as using same passphrase
-func (r *Ripple) WalletPropose(passphrase string) (*ResponseWalletPropose, error) {
+func (r *Ripple) WalletPropose(ctx context.Context, passphrase string) (*ResponseWalletPropose, error) {
 	if r.wsAdmin == nil {
 		return nil, XRPErrorDisabledAdminAPI
 	}
@@ -110,7 +112,7 @@ func (r *Ripple) WalletPropose(passphrase string) (*ResponseWalletPropose, error
 		Passphrase: passphrase,
 	}
 	var res ResponseWalletPropose
-	if err := r.wsAdmin.Call(context.Background(), &req, &res); err != nil {
+	if err := r.wsAdmin.Call(ctx, &req, &res); err != nil {
 		return nil, fmt.Errorf("fail to call wsAdmin.Call(wallet_propose): %w", err)
 	}
 	return &res, nil

--- a/pkg/wallet/api/xrpgrp/xrp/balance.go
+++ b/pkg/wallet/api/xrpgrp/xrp/balance.go
@@ -1,8 +1,10 @@
 package xrp
 
+import "context"
+
 // GetBalance returns amount of address
-func (r *Ripple) GetBalance(addr string) (float64, error) {
-	accountInfo, err := r.GetAccountInfo(addr)
+func (r *Ripple) GetBalance(ctx context.Context, addr string) (float64, error) {
+	accountInfo, err := r.GetAccountInfo(ctx, addr)
 	if err != nil {
 		return 0, err
 	}
@@ -10,10 +12,10 @@ func (r *Ripple) GetBalance(addr string) (float64, error) {
 }
 
 // GetTotalBalance returns total amount in address list
-func (r *Ripple) GetTotalBalance(addrs []string) float64 {
+func (r *Ripple) GetTotalBalance(ctx context.Context, addrs []string) float64 {
 	var total float64
 	for _, addr := range addrs {
-		amt, err := r.GetBalance(addr)
+		amt, err := r.GetBalance(ctx, addr)
 		if err == nil {
 			total += amt
 		}

--- a/pkg/wallet/api/xrpgrp/xrp/public_account.go
+++ b/pkg/wallet/api/xrpgrp/xrp/public_account.go
@@ -80,7 +80,7 @@ type ResponseAccountInfo struct {
 }
 
 // AccountChannels calls account_channels method
-func (r *Ripple) AccountChannels(sender, receiver string) (*ResponseAccountChannels, error) {
+func (r *Ripple) AccountChannels(ctx context.Context, sender, receiver string) (*ResponseAccountChannels, error) {
 	req := AccountChannels{
 		ID:                 1,
 		Command:            "account_channels",
@@ -89,14 +89,14 @@ func (r *Ripple) AccountChannels(sender, receiver string) (*ResponseAccountChann
 		LedgerIndex:        "validated",
 	}
 	var res ResponseAccountChannels
-	if err := r.wsPublic.Call(context.Background(), &req, &res); err != nil {
+	if err := r.wsPublic.Call(ctx, &req, &res); err != nil {
 		return nil, fmt.Errorf("fail to call wsClient.Call(account_channels): %w", err)
 	}
 	return &res, nil
 }
 
 // AccountInfo calls account_channels method
-func (r *Ripple) AccountInfo(address string) (*ResponseAccountInfo, error) {
+func (r *Ripple) AccountInfo(ctx context.Context, address string) (*ResponseAccountInfo, error) {
 	req := AccountInfo{
 		ID:          2,
 		Command:     "account_info",
@@ -106,7 +106,7 @@ func (r *Ripple) AccountInfo(address string) (*ResponseAccountInfo, error) {
 		Queue:       true,
 	}
 	var res ResponseAccountInfo
-	if err := r.wsPublic.Call(context.Background(), &req, &res); err != nil {
+	if err := r.wsPublic.Call(ctx, &req, &res); err != nil {
 		return nil, fmt.Errorf("fail to call wsClient.Call(account_info): %w", err)
 	}
 	return &res, nil

--- a/pkg/wallet/api/xrpgrp/xrp/public_server_info.go
+++ b/pkg/wallet/api/xrpgrp/xrp/public_server_info.go
@@ -85,13 +85,13 @@ type ResponseServerInfo struct {
 }
 
 // ServerInfo calls server_info method
-func (r *Ripple) ServerInfo() (*ResponseServerInfo, error) {
+func (r *Ripple) ServerInfo(ctx context.Context) (*ResponseServerInfo, error) {
 	req := RequestCommand{
 		ID:      1,
 		Command: "server_info",
 	}
 	var res ResponseServerInfo
-	if err := r.wsPublic.Call(context.Background(), &req, &res); err != nil {
+	if err := r.wsPublic.Call(ctx, &req, &res); err != nil {
 		return nil, fmt.Errorf("fail to call wsClient.Call(server_info): %w", err)
 	}
 	return &res, nil

--- a/pkg/wallet/api/xrpgrp/xrp/public_transaction.go
+++ b/pkg/wallet/api/xrpgrp/xrp/public_transaction.go
@@ -84,7 +84,7 @@ type ResponseSign struct {
 }
 
 // Sign calls sign method
-func (r *Ripple) Sign(txJSON *PublicTxType, secret string, offline bool) (*ResponseSign, error) {
+func (r *Ripple) Sign(ctx context.Context, txJSON *PublicTxType, secret string, offline bool) (*ResponseSign, error) {
 	req := Sign{
 		ID:      2,
 		Command: "sign",
@@ -93,7 +93,7 @@ func (r *Ripple) Sign(txJSON *PublicTxType, secret string, offline bool) (*Respo
 		Offline: offline,
 	}
 	var res ResponseSign
-	if err := r.wsPublic.Call(context.Background(), &req, &res); err != nil {
+	if err := r.wsPublic.Call(ctx, &req, &res); err != nil {
 		return nil, fmt.Errorf("fail to call wsClient.Call(sign): %w", err)
 	}
 	return &res, nil

--- a/pkg/wallet/api/xrpgrp/xrp/ripple.go
+++ b/pkg/wallet/api/xrpgrp/xrp/ripple.go
@@ -17,7 +17,6 @@ type Ripple struct {
 	API          *RippleAPI
 	chainConf    *chaincfg.Params
 	coinTypeCode coin.CoinTypeCode // eth
-	ctx          context.Context
 }
 
 // NewRipple creates Ripple object
@@ -34,7 +33,6 @@ func NewRipple(
 		wsAdmin:      wsAdmin,
 		API:          api,
 		coinTypeCode: coinTypeCode,
-		ctx:          ctx,
 	}
 
 	if conf.NetworkType != NetworkTypeXRPMainNet.String() {

--- a/pkg/wallet/api/xrpgrp/xrp/rippleapi_account.go
+++ b/pkg/wallet/api/xrpgrp/xrp/rippleapi_account.go
@@ -9,13 +9,12 @@ import (
 )
 
 // GetAccountInfo calls GetAccountInfo API
-func (r *Ripple) GetAccountInfo(address string) (*ResponseGetAccountInfo, error) {
+func (r *Ripple) GetAccountInfo(ctx context.Context, address string) (*ResponseGetAccountInfo, error) {
 	// validation
 	if address == "" {
 		return nil, errors.New("address is empty")
 	}
 
-	ctx := context.Background()
 	req := &RequestGetAccountInfo{
 		Address: address,
 	}

--- a/pkg/wallet/api/xrpgrp/xrp/rippleapi_address.go
+++ b/pkg/wallet/api/xrpgrp/xrp/rippleapi_address.go
@@ -10,8 +10,7 @@ import (
 )
 
 // GenerateAddress calls GenerateAddress API
-func (r *Ripple) GenerateAddress() (*ResponseGenerateAddress, error) {
-	ctx := context.Background()
+func (r *Ripple) GenerateAddress(ctx context.Context) (*ResponseGenerateAddress, error) {
 	req := &emptypb.Empty{}
 
 	res, err := r.API.addressClient.GenerateAddress(ctx, req)
@@ -29,8 +28,7 @@ func (r *Ripple) GenerateAddress() (*ResponseGenerateAddress, error) {
 }
 
 // GenerateXAddress calls GenerateXAddress API
-func (r *Ripple) GenerateXAddress() (*ResponseGenerateXAddress, error) {
-	ctx := context.Background()
+func (r *Ripple) GenerateXAddress(ctx context.Context) (*ResponseGenerateXAddress, error) {
 	req := &emptypb.Empty{}
 
 	res, err := r.API.addressClient.GenerateXAddress(ctx, req)
@@ -46,8 +44,7 @@ func (r *Ripple) GenerateXAddress() (*ResponseGenerateXAddress, error) {
 }
 
 // IsValidAddress calls IsValidAddress API
-func (r *Ripple) IsValidAddress(addr string) (bool, error) {
-	ctx := context.Background()
+func (r *Ripple) IsValidAddress(ctx context.Context, addr string) (bool, error) {
 	req := &RequestIsValidAddress{
 		Address: addr,
 	}

--- a/pkg/wallet/api/xrpgrp/xrp/rippleapi_tx.go
+++ b/pkg/wallet/api/xrpgrp/xrp/rippleapi_tx.go
@@ -109,9 +109,8 @@ type TxOrderbookChange struct {
 
 // PrepareTransaction calls PrepareTransaction API
 func (r *Ripple) PrepareTransaction(
-	senderAccount, receiverAccount string, amount float64, instructions *Instructions,
+	ctx context.Context, senderAccount, receiverAccount string, amount float64, instructions *Instructions,
 ) (*TxInput, string, error) {
-	ctx := context.Background()
 	req := &RequestPrepareTransaction{
 		TxType:          EnumTransactionType_TX_PAYMENT,
 		SenderAccount:   senderAccount,
@@ -141,8 +140,7 @@ func (r *Ripple) PrepareTransaction(
 // SignTransaction calls SignTransaction API
 // Offline functionality
 // - https://xrpl.org/rippleapi-reference.html#offline-functionality
-func (r *Ripple) SignTransaction(txInput *TxInput, secret string) (string, string, error) {
-	ctx := context.Background()
+func (r *Ripple) SignTransaction(ctx context.Context, txInput *TxInput, secret string) (string, string, error) {
 	strJSON, err := json.Marshal(txInput)
 	if err != nil {
 		return "", "", fmt.Errorf("fail to call json.Marshal(txJSON): %w", err)
@@ -162,8 +160,7 @@ func (r *Ripple) SignTransaction(txInput *TxInput, secret string) (string, strin
 
 // CombineTransaction combines signed transactions from multiple accounts for a multisignature transaction.
 // - The signed transaction must subsequently be submitted.
-func (r *Ripple) CombineTransaction(signedTxs []string) (string, string, error) {
-	ctx := context.Background()
+func (r *Ripple) CombineTransaction(ctx context.Context, signedTxs []string) (string, string, error) {
 	req := &RequestCombineTransaction{
 		SignedTransactions: signedTxs,
 	}
@@ -178,8 +175,7 @@ func (r *Ripple) CombineTransaction(signedTxs []string) (string, string, error) 
 
 // SubmitTransaction calls SubmitTransaction API
 // - signedTx is returned TxBlob by SignTransaction()
-func (r *Ripple) SubmitTransaction(signedTx string) (*SentTx, uint64, error) {
-	ctx := context.Background()
+func (r *Ripple) SubmitTransaction(ctx context.Context, signedTx string) (*SentTx, uint64, error) {
 	req := &RequestSubmitTransaction{
 		TxBlob: signedTx,
 	}
@@ -209,8 +205,7 @@ func (r *Ripple) SubmitTransaction(signedTx string) (*SentTx, uint64, error) {
 
 // WaitValidation calls WaitValidation API
 // - handling server streaming
-func (r *Ripple) WaitValidation(targetledgerVarsion uint64) (uint64, error) {
-	ctx := context.Background()
+func (r *Ripple) WaitValidation(ctx context.Context, targetledgerVarsion uint64) (uint64, error) {
 	req := &emptypb.Empty{}
 	resStream, err := r.API.txClient.WaitValidation(ctx, req)
 	if err != nil {
@@ -268,8 +263,7 @@ func (r *Ripple) WaitValidation(targetledgerVarsion uint64) (uint64, error) {
 }
 
 // GetTransaction calls GetTransaction API
-func (r *Ripple) GetTransaction(txID string, targetLedgerVersion uint64) (*TxInfo, error) {
-	ctx := context.Background()
+func (r *Ripple) GetTransaction(ctx context.Context, txID string, targetLedgerVersion uint64) (*TxInfo, error) {
 	req := &RequestGetTransaction{
 		TxID:             txID,
 		MinLedgerVersion: targetLedgerVersion,

--- a/pkg/wallet/api/xrpgrp/xrp/transaction.go
+++ b/pkg/wallet/api/xrpgrp/xrp/transaction.go
@@ -1,6 +1,7 @@
 package xrp
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -10,7 +11,7 @@ import (
 // CreateRawTransaction creates raw transaction
 // - https://xrpl.org/ja/send-xrp.html
 func (r *Ripple) CreateRawTransaction(
-	senderAccount, receiverAccount string, amount float64, instructions *Instructions,
+	ctx context.Context, senderAccount, receiverAccount string, amount float64, instructions *Instructions,
 ) (*TxInput, string, error) {
 	// validation
 	if senderAccount == "" {
@@ -22,7 +23,7 @@ func (r *Ripple) CreateRawTransaction(
 
 	// get balance
 	// xrp.MinimumReserve
-	accountInfo, err := r.GetAccountInfo(senderAccount)
+	accountInfo, err := r.GetAccountInfo(ctx, senderAccount)
 	if err != nil {
 		errStatus, _ := status.FromError(err)
 		return nil, "", fmt.Errorf(
@@ -34,7 +35,7 @@ func (r *Ripple) CreateRawTransaction(
 	}
 
 	// get fee
-	txJSON, stringJSON, err := r.PrepareTransaction(senderAccount, receiverAccount, amount, instructions)
+	txJSON, stringJSON, err := r.PrepareTransaction(ctx, senderAccount, receiverAccount, amount, instructions)
 	if err != nil {
 		return nil, "", fmt.Errorf("fail to call PrepareTransaction(): %w", err)
 	}
@@ -45,7 +46,8 @@ func (r *Ripple) CreateRawTransaction(
 			return nil, "", fmt.Errorf("balance is short to send %s", accountInfo.XrpBalance)
 		}
 		// re-run
-		txJSON, stringJSON, err = r.PrepareTransaction(senderAccount, receiverAccount, calculatedAmount, instructions)
+		txJSON, stringJSON, err = r.PrepareTransaction(
+			ctx, senderAccount, receiverAccount, calculatedAmount, instructions)
 		if err != nil {
 			return nil, "", fmt.Errorf("fail to call PrepareTransaction(): %w", err)
 		}

--- a/pkg/wallet/service/eth/watchsrv/tx_creator_deposit.go
+++ b/pkg/wallet/service/eth/watchsrv/tx_creator_deposit.go
@@ -1,6 +1,7 @@
 package watchsrv
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 
@@ -77,7 +78,7 @@ func (t *TxCreate) getUserAmounts(sender account.AccountType) ([]eth.UserAmount,
 	for _, addr := range addrs {
 		// TODO: if previous tx is not done, wrong amount is returned. how to manage it??
 		var balance *big.Int
-		balance, err = t.eth.GetBalance(addr.WalletAddress, eth.QuantityTagLatest)
+		balance, err = t.eth.GetBalance(context.TODO(), addr.WalletAddress, eth.QuantityTagLatest)
 		if err != nil {
 			logger.Warn("fail to call .GetBalance()",
 				"address", addr.WalletAddress,
@@ -108,7 +109,8 @@ func (t *TxCreate) createDepositRawTransactions(
 		// call CreateRawTransaction
 		var rawTx *ethtx.RawTx
 		var txDetailItem *models.EthDetailTX
-		rawTx, txDetailItem, err = t.eth.CreateRawTransaction(val.Address, depositAddr.WalletAddress, 0, 0)
+		rawTx, txDetailItem, err = t.eth.CreateRawTransaction(
+			context.TODO(), val.Address, depositAddr.WalletAddress, 0, 0)
 		if err != nil {
 			return nil, nil, fmt.Errorf(
 				"fail to call addrRepo.CreateRawTransaction(), sender address: %s: %w",

--- a/pkg/wallet/service/eth/watchsrv/tx_creator_payment.go
+++ b/pkg/wallet/service/eth/watchsrv/tx_creator_payment.go
@@ -1,6 +1,7 @@
 package watchsrv
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math/big"
@@ -135,7 +136,7 @@ func (t *TxCreate) createUserPayment() ([]UserPayment, *big.Int, []int64, error)
 
 func (t *TxCreate) validateAmount(senderAddr *models.Address, totalAmount *big.Int) error {
 	// check sender's total balance
-	senderBalance, err := t.eth.GetBalance(senderAddr.WalletAddress, eth.QuantityTagPending)
+	senderBalance, err := t.eth.GetBalance(context.TODO(), senderAddr.WalletAddress, eth.QuantityTagPending)
 	if err != nil {
 		return fmt.Errorf("fail to call eth.GetBalance(): %w", err)
 	}
@@ -154,7 +155,7 @@ func (t *TxCreate) createPaymentRawTransactions(
 	additionalNonce := 0
 	for _, userPayment := range userPayments {
 		// call CreateRawTransaction
-		rawTx, txDetailItem, err := t.eth.CreateRawTransaction(
+		rawTx, txDetailItem, err := t.eth.CreateRawTransaction(context.TODO(),
 			senderAddr.WalletAddress, userPayment.receiverAddr, userPayment.amount.Uint64(), additionalNonce)
 		if err != nil {
 			return nil, nil, fmt.Errorf(

--- a/pkg/wallet/service/eth/watchsrv/tx_creator_transfer.go
+++ b/pkg/wallet/service/eth/watchsrv/tx_creator_transfer.go
@@ -1,6 +1,7 @@
 package watchsrv
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -32,7 +33,7 @@ func (t *TxCreate) CreateTransferTx(sender, receiver account.AccountType, floatV
 	if err != nil {
 		return "", "", fmt.Errorf("fail to call addrRepo.GetOneUnAllocated(sender): %w", err)
 	}
-	senderBalnce, err := t.eth.GetBalance(senderAddr.WalletAddress, eth.QuantityTagLatest)
+	senderBalnce, err := t.eth.GetBalance(context.TODO(), senderAddr.WalletAddress, eth.QuantityTagLatest)
 	if err != nil {
 		return "", "", fmt.Errorf("fail to call eth.GetBalance(sender): %w", err)
 	}
@@ -58,7 +59,7 @@ func (t *TxCreate) CreateTransferTx(sender, receiver account.AccountType, floatV
 	}
 
 	// call CreateRawTransaction
-	rawTx, txDetailItem, err := t.eth.CreateRawTransaction(
+	rawTx, txDetailItem, err := t.eth.CreateRawTransaction(context.TODO(),
 		senderAddr.WalletAddress, receiverAddr.WalletAddress, requiredValue.Uint64(), 0)
 	if err != nil {
 		return "", "", fmt.Errorf(

--- a/pkg/wallet/service/eth/watchsrv/tx_monitor.go
+++ b/pkg/wallet/service/eth/watchsrv/tx_monitor.go
@@ -1,6 +1,7 @@
 package watchsrv
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 
@@ -73,7 +74,7 @@ func (t *TxMonitor) updateStatusTxTypeSent() error {
 	for _, sentHash := range hashes {
 		// check confirmation
 		var confirmNum uint64
-		confirmNum, err = t.eth.GetConfirmation(sentHash)
+		confirmNum, err = t.eth.GetConfirmation(context.TODO(), sentHash)
 		if err != nil {
 			return fmt.Errorf("fail to call eth.GetConfirmation() sentHash: %s: %w", sentHash, err)
 		}
@@ -108,7 +109,7 @@ func (t *TxMonitor) MonitorBalance(_ uint64) error {
 		if err != nil {
 			return fmt.Errorf("fail to call addrRepo.GetAllAddress(): %w", err)
 		}
-		total, _ := t.eth.GetTotalBalance(addrs)
+		total, _ := t.eth.GetTotalBalance(context.TODO(), addrs)
 		logger.Info("total balance",
 			"account", acnt.String(),
 			"balance", total.Uint64())

--- a/pkg/wallet/service/eth/watchsrv/tx_sender.go
+++ b/pkg/wallet/service/eth/watchsrv/tx_sender.go
@@ -1,6 +1,7 @@
 package watchsrv
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -75,7 +76,7 @@ func (t *TxSend) SendTx(filePath string) (string, error) {
 
 		// sign
 		var sentTx string
-		sentTx, err = t.eth.SendSignedRawTransaction(signedTx)
+		sentTx, err = t.eth.SendSignedRawTransaction(context.TODO(), signedTx)
 		if err != nil {
 			logger.Warn("fail to call eth.SendSignedRawTransaction()",
 				"error", err,

--- a/pkg/wallet/service/xrp/keygensrv/key_generator.go
+++ b/pkg/wallet/service/xrp/keygensrv/key_generator.go
@@ -1,6 +1,7 @@
 package keygensrv
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 
@@ -76,7 +77,7 @@ func (k *XRPKeyGenerate) Generate(accountType account.AccountType, isKeyPair boo
 		// - WIF => badSeed
 		// - P2PKHAddr => badSeed
 		var generatedKey *xrp.ResponseWalletPropose
-		generatedKey, err = k.xrp.WalletPropose(v.P2SHSegWitAddr)
+		generatedKey, err = k.xrp.WalletPropose(context.TODO(), v.P2SHSegWitAddr)
 		if err != nil {
 			return fmt.Errorf("fail to call xrp.WalletPropose(): %w", err)
 		}

--- a/pkg/wallet/service/xrp/keygensrv/signer.go
+++ b/pkg/wallet/service/xrp/keygensrv/signer.go
@@ -1,6 +1,7 @@
 package keygensrv
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -86,7 +87,7 @@ func (s *Sign) SignTx(filePath string) (string, bool, string, error) {
 		// sign
 		var signedTxID string
 		var txBlob string
-		signedTxID, txBlob, err = s.xrp.SignTransaction(&txInput, secret)
+		signedTxID, txBlob, err = s.xrp.SignTransaction(context.TODO(), &txInput, secret)
 		if err != nil {
 			return "", false, "", fmt.Errorf("fail to call xrp.SignTransaction(): %w", err)
 		}

--- a/pkg/wallet/service/xrp/watchsrv/tx_creator_deposit.go
+++ b/pkg/wallet/service/xrp/watchsrv/tx_creator_deposit.go
@@ -1,6 +1,7 @@
 package watchsrv
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/bookerzzz/grok"
@@ -73,7 +74,7 @@ func (t *TxCreate) getUserAmounts(sender account.AccountType) ([]xrp.UserAmount,
 	for _, addr := range addrs {
 		// TODO: if previous tx is not done, wrong amount is returned. how to manage it??
 		var clientBalance float64
-		clientBalance, err = t.xrp.GetBalance(addr.WalletAddress)
+		clientBalance, err = t.xrp.GetBalance(context.TODO(), addr.WalletAddress)
 		if err != nil {
 			logger.Warn("fail to call t.xrp.GetAccountInfo()",
 				"address", addr.WalletAddress,
@@ -113,7 +114,8 @@ func (t *TxCreate) createDepositRawTransactions(
 		}
 		var txJSON *xrp.TxInput
 		var rawTxString string
-		txJSON, rawTxString, err = t.xrp.CreateRawTransaction(val.Address, depositAddr.WalletAddress, 0, instructions)
+		txJSON, rawTxString, err = t.xrp.CreateRawTransaction(
+			context.TODO(), val.Address, depositAddr.WalletAddress, 0, instructions)
 		if err != nil {
 			logger.Warn("fail to call xrp.CreateRawTransaction()", "error", err)
 			continue

--- a/pkg/wallet/service/xrp/watchsrv/tx_creator_payment.go
+++ b/pkg/wallet/service/xrp/watchsrv/tx_creator_payment.go
@@ -1,6 +1,7 @@
 package watchsrv
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -133,7 +134,7 @@ func (t *TxCreate) createUserPayment() ([]UserPayment, float64, []int64, error) 
 }
 
 func (t *TxCreate) validateAmount(senderAddr *models.Address, totalAmount float64) error {
-	senderBalance, err := t.xrp.GetBalance(senderAddr.WalletAddress)
+	senderBalance, err := t.xrp.GetBalance(context.TODO(), senderAddr.WalletAddress)
 	if err != nil {
 		return fmt.Errorf("fail to call xrp.GetAccountInfo(): %w", err)
 	}
@@ -159,7 +160,7 @@ func (t *TxCreate) createPaymentRawTransactions(
 			instructions.Sequence = sequence
 		}
 		txJSON, rawTxString, err := t.xrp.CreateRawTransaction(
-			senderAddr.WalletAddress, userPayment.receiverAddr, userPayment.floatAmount, instructions)
+			context.TODO(), senderAddr.WalletAddress, userPayment.receiverAddr, userPayment.floatAmount, instructions)
 		if err != nil {
 			// TODO: which is better to return err or continue?
 			// return error in ethereum logic

--- a/pkg/wallet/service/xrp/watchsrv/tx_creator_transfer.go
+++ b/pkg/wallet/service/xrp/watchsrv/tx_creator_transfer.go
@@ -1,6 +1,7 @@
 package watchsrv
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -34,7 +35,7 @@ func (t *TxCreate) CreateTransferTx(sender, receiver account.AccountType, floatV
 	if err != nil {
 		return "", "", fmt.Errorf("fail to call addrRepo.GetOneUnAllocated(sender): %w", err)
 	}
-	senderBalance, err := t.xrp.GetBalance(senderAddr.WalletAddress)
+	senderBalance, err := t.xrp.GetBalance(context.TODO(), senderAddr.WalletAddress)
 	if err != nil {
 		return "", "", fmt.Errorf("fail to call xrp.GetAccountInfo(): %w", err)
 	}
@@ -61,7 +62,7 @@ func (t *TxCreate) CreateTransferTx(sender, receiver account.AccountType, floatV
 		MaxLedgerVersionOffset: xrp.MaxLedgerVersionOffset,
 	}
 	txJSON, rawTxString, err := t.xrp.CreateRawTransaction(
-		senderAddr.WalletAddress, receiverAddr.WalletAddress, floatValue, instructions)
+		context.TODO(), senderAddr.WalletAddress, receiverAddr.WalletAddress, floatValue, instructions)
 	if err != nil {
 		return "", "", fmt.Errorf(
 			"fail to call xrp.CreateRawTransaction(), sender address: %s: %w",

--- a/pkg/wallet/service/xrp/watchsrv/tx_monitor.go
+++ b/pkg/wallet/service/xrp/watchsrv/tx_monitor.go
@@ -1,6 +1,7 @@
 package watchsrv
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 
@@ -57,7 +58,7 @@ func (t *TxMonitor) MonitorBalance(_ uint64) error {
 		if err != nil {
 			return fmt.Errorf("fail to call addrRepo.GetAllAddress(): %w", err)
 		}
-		total := t.xrp.GetTotalBalance(addrs)
+		total := t.xrp.GetTotalBalance(context.TODO(), addrs)
 		logger.Info("total balance",
 			"account", acnt.String(),
 			"balance", total)

--- a/pkg/wallet/service/xrp/watchsrv/tx_sender.go
+++ b/pkg/wallet/service/xrp/watchsrv/tx_sender.go
@@ -1,6 +1,7 @@
 package watchsrv
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"strings"
@@ -98,7 +99,7 @@ func (t *TxSend) SendTx(filePath string) (string, error) {
 			// submit
 			var sentTx *xrp.SentTx
 			var earlistLedgerVersion uint64
-			sentTx, earlistLedgerVersion, err = t.rippler.SubmitTransaction(txBlob)
+			sentTx, earlistLedgerVersion, err = t.rippler.SubmitTransaction(context.TODO(), txBlob)
 			if err != nil {
 				logger.Warn("fail to call xrp.SubmitTransaction()",
 					"tx_id", txID,
@@ -135,7 +136,7 @@ func (t *TxSend) SendTx(filePath string) (string, error) {
 
 			// validate transaction
 			var ledgerVer uint64
-			ledgerVer, err = t.rippler.WaitValidation(sentTx.TxJSON.LastLedgerSequence)
+			ledgerVer, err = t.rippler.WaitValidation(context.TODO(), sentTx.TxJSON.LastLedgerSequence)
 			if err != nil {
 				logger.Warn("fail to call xrp.WaitValidation()",
 					"tx_id", txID,
@@ -151,7 +152,7 @@ func (t *TxSend) SendTx(filePath string) (string, error) {
 
 			// get transaction info
 			var txInfo *xrp.TxInfo
-			txInfo, err = t.rippler.GetTransaction(sentTx.TxJSON.Hash, earlistLedgerVersion)
+			txInfo, err = t.rippler.GetTransaction(context.TODO(), sentTx.TxJSON.Hash, earlistLedgerVersion)
 			if err != nil {
 				logger.Warn("fail to call xrp.GetTransaction()",
 					"tx_id", txID,


### PR DESCRIPTION
## Summary

This PR implements a refactoring to follow Go best practices for context management by removing `context.Context` from struct fields in the `Ethereum` and `Ripple` types.

Closes #49

## Changes

### Core Refactoring
- ✅ **Ethereum struct**: Removed `ctx` field and updated 45+ methods across 10 files
- ✅ **Ripple struct**: Removed `ctx` field and updated 18+ methods across 9 files
- ✅ **Interface updates**: Updated all interface signatures in `api-interface.go` files
- ✅ **Call site updates**: Updated all method call sites to pass context

### Implementation Details

#### Ethereum (`pkg/wallet/api/ethgrp/eth/`)
- Removed `ctx context.Context` field from struct
- Added `ctx context.Context` as the first parameter to all methods
- Updated files:
  - `ethereum.go` - Constructor updated to use context only for initialization
  - `rpc_eth.go` - 13 methods updated
  - `rpc_eth_tx.go` - 6 methods updated (including special handling for `context.WithTimeout`)
  - `rpc_eth_gas.go` - 2 methods updated
  - `rpc_miner.go` - 4 methods updated
  - `rpc_web3.go` - 2 methods updated
  - `rpc_admin.go` - 4 methods updated
  - `rpc_net.go` - 3 methods updated
  - `rpc_personal.go` - 5 methods updated
  - `client.go` - 2 methods updated
  - `balance.go` - 1 method updated
  - `transaction.go` - 5 methods updated

#### Ripple (`pkg/wallet/api/xrpgrp/xrp/`)
- Removed `ctx context.Context` field from struct
- Added `ctx context.Context` as the first parameter to all methods
- Replaced all `context.Background()` calls with `ctx` parameter
- Updated files:
  - `ripple.go` - Constructor updated
  - `rippleapi_tx.go` - 6 methods updated
  - `rippleapi_address.go` - 3 methods updated
  - `rippleapi_account.go` - 1 method updated
  - `public_account.go` - 2 methods updated
  - `public_transaction.go` - 1 method updated
  - `public_server_info.go` - 1 method updated
  - `admin_keygen.go` - 3 methods updated
  - `balance.go` - 2 methods updated
  - `transaction.go` - 1 method updated

#### Service and Command Layers
- Service layer: Updated to use `context.TODO()` for gradual context propagation
- Command layer: Updated to use `context.Background()` at entry points
- Files updated across `pkg/wallet/service/eth/watchsrv/` and `pkg/wallet/service/xrp/`

## Benefits

1. **Proper Context Lifecycle**: Context is now request-scoped rather than persisted in long-lived objects
2. **Thread Safety**: Eliminates potential concurrency issues from shared struct context
3. **Flexibility**: Callers can now provide different contexts for various operations
4. **Go Best Practices**: Follows standard Go idioms and community conventions
5. **No Breaking Logic**: Purely mechanical refactoring with no logic changes

## Testing

✅ **Linting**: `make lint-fix` - 0 issues  
✅ **Build**: `make check-build` - All targets build successfully  
✅ **Tests**: `make gotest` - All tests pass  
✅ **Dependencies**: `make tidy` - Clean

## Migration Notes

This is a **breaking change** for external users of the `Ethereum` and `Ripple` types. All method calls now require passing a `context.Context` as the first parameter.

### Before:
```go
balance, err := eth.GetBalance(address, eth.QuantityTagLatest)
```

### After:
```go
balance, err := eth.GetBalance(ctx, address, eth.QuantityTagLatest)
```

## Review Checklist

- [x] Context removed from struct fields
- [x] All methods accept `ctx context.Context` as first parameter
- [x] All interfaces updated to match
- [x] All call sites updated
- [x] Tests pass
- [x] Linting clean
- [x] Build successful
- [x] No logic changes (purely mechanical refactoring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)