### PR TITLE
fix: Address review comments from PR #60

### DIFF
--- a/pkg/domain/account/validator.go
+++ b/pkg/domain/account/validator.go
@@ -3,6 +3,7 @@ package account
 import (
 	"errors"
 	"fmt"
+	"strings"
 )
 
 // CanTransferFrom returns true if the account type can be used as a sender in transfers.
@@ -41,22 +42,7 @@ func ValidateTransferAccounts(sender, receiver AccountType) error {
 
 // IsAuthorizationAccount returns true if the account type is an authorization account.
 func IsAuthorizationAccount(accountType AccountType) bool {
-	return accountType == AccountTypeAuthorization ||
-		accountType == AccountTypeAuth1 ||
-		accountType == AccountTypeAuth2 ||
-		accountType == AccountTypeAuth3 ||
-		accountType == AccountTypeAuth4 ||
-		accountType == AccountTypeAuth5 ||
-		accountType == AccountTypeAuth6 ||
-		accountType == AccountTypeAuth7 ||
-		accountType == AccountTypeAuth8 ||
-		accountType == AccountTypeAuth9 ||
-		accountType == AccountTypeAuth10 ||
-		accountType == AccountTypeAuth11 ||
-		accountType == AccountTypeAuth12 ||
-		accountType == AccountTypeAuth13 ||
-		accountType == AccountTypeAuth14 ||
-		accountType == AccountTypeAuth15
+	return strings.HasPrefix(string(accountType), "auth")
 }
 
 // IsMultisigEligible returns true if the account type can have multisig addresses.

--- a/pkg/domain/coin/types.go
+++ b/pkg/domain/coin/types.go
@@ -63,8 +63,8 @@ const (
 	// ERC20 represents generic ERC20 tokens
 	ERC20 CoinTypeCode = "erc20"
 
-	// HYC represents HYT token (custom ERC20)
-	HYC CoinTypeCode = "hyt"
+	// HYT represents HYT token (custom ERC20)
+	HYT CoinTypeCode = "hyt"
 )
 
 // String returns the string representation of the coin type code.
@@ -80,7 +80,7 @@ var CoinTypeCodeValue = map[CoinTypeCode]CoinType{
 	ETH:   CoinTypeEther,
 	XRP:   CoinTypeRipple,
 	ERC20: CoinTypeERC20,
-	HYC:   CoinTypeERC20HYT,
+	HYT:   CoinTypeERC20HYT,
 }
 
 // IsCoinTypeCode validates whether the given string is a valid coin type code.
@@ -96,7 +96,7 @@ func IsBTCGroup(val CoinTypeCode) bool {
 
 // IsETHGroup returns true if the coin is part of the Ethereum group (ETH, ERC20 tokens).
 func IsETHGroup(val CoinTypeCode) bool {
-	return val == ETH || IsERC20Token(val.String())
+	return val == ETH || val == ERC20 || IsERC20Token(val.String())
 }
 
 // ERC20Token represents ERC20 token identifiers.
@@ -104,11 +104,11 @@ type ERC20Token string
 
 // ERC20 token constants
 const (
-	// HYT represents HYT token
-	HYT ERC20Token = "hyt"
+	// TokenHYT represents HYT token
+	TokenHYT ERC20Token = "hyt"
 
-	// BAT represents Basic Attention Token
-	BAT ERC20Token = "bat"
+	// TokenBAT represents Basic Attention Token
+	TokenBAT ERC20Token = "bat"
 )
 
 // String returns the string representation of the ERC20 token.
@@ -118,8 +118,8 @@ func (e ERC20Token) String() string {
 
 // ERC20Map maps known ERC20 tokens for validation.
 var ERC20Map = map[ERC20Token]bool{
-	HYT: true,
-	BAT: true,
+	TokenHYT: true,
+	TokenBAT: true,
 }
 
 // IsERC20Token validates whether the given string is a known ERC20 token.

--- a/pkg/domain/key/validator.go
+++ b/pkg/domain/key/validator.go
@@ -46,8 +46,11 @@ func ValidateKeyRange(idxFrom, count uint32) error {
 
 	// Check for overflow
 	const maxNormalIndex = 0x7FFFFFFF
-	if idxFrom+count-1 > maxNormalIndex {
-		return fmt.Errorf("key range [%d, %d] exceeds maximum index %d", idxFrom, idxFrom+count-1, maxNormalIndex)
+	if idxFrom > maxNormalIndex-(count-1) {
+		return fmt.Errorf(
+			"key range with start %d and count %d exceeds maximum index %d",
+			idxFrom, count, maxNormalIndex,
+		)
 	}
 
 	return nil

--- a/pkg/domain/transaction/validator.go
+++ b/pkg/domain/transaction/validator.go
@@ -28,7 +28,9 @@ func ValidateSenderReceiver(sender, receiver account.AccountType, actionType Act
 		if sender != account.AccountTypeClient {
 			return fmt.Errorf("deposit transactions must have client as sender, got %s", sender)
 		}
-		// Receiver should be deposit account, but this is typically configured
+		if receiver != account.AccountTypeDeposit {
+			return fmt.Errorf("deposit transactions must have deposit as receiver, got %s", receiver)
+		}
 
 	case ActionTypePayment:
 		// Payment: from payment account to external addresses
@@ -61,13 +63,8 @@ func ValidateTransactionType(txType TxType) error {
 // CanTransitionTo checks if a transaction can transition from one state to another.
 // This enforces the transaction state machine:
 // unsigned → signed → sent → done → (optional: notified)
-// Any state can transition to canceled
+// Cancellation is only allowed before the transaction is confirmed (done)
 func CanTransitionTo(from, to TxType) bool {
-	// Can always cancel
-	if to == TxTypeCancel {
-		return true
-	}
-
 	// Define valid transitions
 	validTransitions := map[TxType][]TxType{
 		TxTypeUnsigned: {TxTypeSigned, TxTypeCancel},

--- a/pkg/wallet/coin/erc20.go
+++ b/pkg/wallet/coin/erc20.go
@@ -16,8 +16,8 @@ type ERC20Token = domainCoin.ERC20Token
 //
 // Deprecated: Use constants from domain/coin package
 const (
-	HYT = domainCoin.HYT
-	BAT = domainCoin.BAT
+	TokenHYT = domainCoin.TokenHYT
+	TokenBAT = domainCoin.TokenBAT
 )
 
 // ERC20Map map of ERC20 tokens

--- a/pkg/wallet/coin/types.go
+++ b/pkg/wallet/coin/types.go
@@ -43,7 +43,8 @@ const (
 	ETH   = domainCoin.ETH
 	XRP   = domainCoin.XRP
 	ERC20 = domainCoin.ERC20
-	HYC   = domainCoin.HYC
+	HYT   = domainCoin.HYT
+	HYC   = domainCoin.HYT // Deprecated: Use HYT instead
 )
 
 // GetCoinType returns CoinType based on network configuration


### PR DESCRIPTION
## Summary

This PR addresses all 6 review comments from the merged PR #60 (Domain Layer Separation):

### Critical Fixes
- **Integer overflow fix**: Fixed potential integer overflow in `ValidateKeyRange` by reordering subtraction operation (pkg/domain/key/validator.go:51)
- **Transaction state machine fix**: Fixed bug in `CanTransitionTo` that incorrectly allowed canceling terminal states (done/notified) (pkg/domain/transaction/validator.go:69)

### High Priority Fix
- **ERC20 group validation**: Added explicit check for generic ERC20 type in `IsETHGroup` function (pkg/domain/coin/types.go:100)

### Medium Priority Fixes  
- **Code simplification**: Simplified `IsAuthorizationAccount` using `strings.HasPrefix` instead of 17-line OR chain (pkg/domain/account/validator.go:45)
- **Naming consistency**: Separated `CoinTypeCode` and `ERC20Token` namespaces by prefixing ERC20Token constants with 'Token' to resolve naming collision (pkg/domain/coin/types.go)
- **Validation completeness**: Added receiver validation for `ActionTypeDeposit` to ensure deposit account is the receiver, matching the pattern used for payment transactions (pkg/domain/transaction/validator.go:31)

## Test plan

- [x] All linting checks pass (`make lint-fix`)
- [x] Code builds successfully (`make check-build`)
- [x] All tests pass (`make gotest`)

## Related Issues

Fixes review comments from #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)