### PR TITLE
[PSBT Phase 2.6] Sign Wallet - Implement PSBT Signing (Issue #97)

### DIFF
--- a/internal/application/usecase/sign/btc/sign_transaction_test.go
+++ b/internal/application/usecase/sign/btc/sign_transaction_test.go
@@ -20,6 +20,7 @@ func TestNewSignTransactionUseCase(t *testing.T) {
 			nil, // txFileRepo
 			nil, // multisigAccount
 			domainWallet.WalletTypeSign,
+			"auth1", // authType
 		)
 
 		assert.NotNil(t, useCase, "use case should not be nil")
@@ -33,6 +34,7 @@ func TestNewSignTransactionUseCase(t *testing.T) {
 			nil,
 			nil,
 			domainWallet.WalletTypeSign,
+			"auth1", // authType
 		)
 
 		// Verify it implements the interface

--- a/internal/application/usecase/sign/eth/sign_transaction.go
+++ b/internal/application/usecase/sign/eth/sign_transaction.go
@@ -78,7 +78,7 @@ func (u *signTransactionUseCase) Sign(
 
 	// return hexTx, isSigned, generatedFileName, nil
 	return signusecase.SignTransactionOutput{
-		SignedHex:    "",
+		SignedData:   "",
 		IsComplete:   true,
 		NextFilePath: generatedFileName,
 	}, nil

--- a/internal/application/usecase/sign/interfaces.go
+++ b/internal/application/usecase/sign/interfaces.go
@@ -45,7 +45,7 @@ type SignTransactionInput struct {
 
 // SignTransactionOutput represents output from signing a transaction
 type SignTransactionOutput struct {
-	SignedHex    string
+	SignedData   string // Signed transaction data (hex for legacy, base64 PSBT for BTC)
 	IsComplete   bool
 	NextFilePath string
 }

--- a/internal/application/usecase/sign/xrp/sign_transaction.go
+++ b/internal/application/usecase/sign/xrp/sign_transaction.go
@@ -108,7 +108,7 @@ func (u *signTransactionUseCase) Sign(
 
 	// return hexTx, isSigned, generatedFileName, nil
 	return signusecase.SignTransactionOutput{
-		SignedHex:    "",
+		SignedData:   "",
 		IsComplete:   true,
 		NextFilePath: generatedFileName,
 	}, nil

--- a/internal/di/container.go
+++ b/internal/di/container.go
@@ -1099,6 +1099,7 @@ func (c *container) newBTCSignTransactionUseCase() signusecase.SignTransactionUs
 		c.newTxFileStorager(),
 		c.newMultiAccount(),
 		c.walletType,
+		c.AuthType(),
 	)
 }
 

--- a/internal/interface-adapters/cli/sign/sign/sign.go
+++ b/internal/interface-adapters/cli/sign/sign/sign.go
@@ -45,8 +45,8 @@ func runSignature(container di.Container, filePath string) error {
 	}
 
 	// TODO: output should be json if json option is true
-	fmt.Printf("[hex]: %s\n[isCompleted]: %t\n[fileName]: %s\n",
-		output.SignedHex, output.IsComplete, output.NextFilePath)
+	fmt.Printf("[signedData]: %s\n[isCompleted]: %t\n[fileName]: %s\n",
+		output.SignedData, output.IsComplete, output.NextFilePath)
 
 	return nil
 }

--- a/internal/interface-adapters/wallet/btc/sign.go
+++ b/internal/interface-adapters/wallet/btc/sign.go
@@ -113,7 +113,7 @@ func (s *BTCSign) SignTx(filePath string) (string, bool, string, error) {
 		return "", false, "", err
 	}
 
-	return output.SignedHex, output.IsComplete, output.NextFilePath, nil
+	return output.SignedData, output.IsComplete, output.NextFilePath, nil
 }
 
 // Done should be called before exit


### PR DESCRIPTION
## Summary

This PR implements PSBT signing for the Sign wallet, completing Issue #97 (Phase 2.6 of PSBT implementation). The Sign wallet now adds the second signature to partially signed PSBTs from the Keygen wallet, completing multisig transactions offline using the btcd library.

## Changes

### Core Implementation

- **Replace CSV with PSBT**: Replaced CSV-based transaction file handling with PSBT file operations
  - `ReadFile()` → `ReadPSBTFile()` for reading partially signed PSBTs
  - `WriteFile()` → `WritePSBTFile()` for writing fully signed PSBTs
  - `ValidateFilePath()` updated to expect `.psbt` extension

- **Offline Signing**: Replaced Bitcoin Core RPC with btcd library for offline signing
  - `SignRawTransactionWithKey()` → `SignPSBTWithKey()` for PSBT signing
  - No Bitcoin Core RPC dependency - fully offline operation
  - Supports all multisig address types: P2SH, P2WSH, P2TR (Taproot script path)

- **Auth Key Usage**: Sign wallet uses auth key from auth_account_key table
  - Gets single auth key using `authKeyRepo.GetOne("")`
  - Adds second signature to complete multisig (2-of-2 or 2-of-N)
  - Different from Keygen wallet which uses account keys

### File Changes

- `internal/application/usecase/sign/btc/sign_transaction.go`:
  - Updated `Sign()` method to read/write PSBT files
  - Simplified `sign()` method to work with PSBT
  - Replaced `signMultisig()` with `signMultisigPSBT()` method
  - Removed CSV parsing and serialization logic
  - Added comprehensive PSBT signing documentation

- `internal/application/usecase/sign/btc/sign_transaction_test.go` (new):
  - Constructor tests following project pattern
  - Interface compliance verification
  - Comprehensive testing strategy documentation

### Removed Dependencies

- `"errors"` - no longer needed
- `"strings"` - CSV parsing removed
- `"github.com/btcsuite/btcd/wire"` - replaced with PSBT operations
- `"github.com/hiromaily/go-crypto-wallet/internal/infrastructure/api/bitcoin/btc"` - no longer needed
- `"github.com/hiromaily/go-crypto-wallet/pkg/serial"` - CSV serialization removed

## Technical Details

### PSBT Signing Flow

1. **Read PSBT**: `ReadPSBTFile()` reads base64-encoded partially signed PSBT
2. **Get Auth Key**: Retrieve Sign wallet's auth key from auth_account_key table
3. **Sign**: `SignPSBTWithKey()` adds second signature (btcd handles everything)
4. **Check Completion**: btcd returns `isSigned=true` if multisig requirements met
5. **Write Result**: `WritePSBTFile()` saves fully signed PSBT

### Multisig Support

- For 2-of-2 multisig, Sign wallet completes the transaction (fully signed)
- For 2-of-N multisig (N>2), transaction is complete after second signature
- If more signatures needed (rare), increment `signedCount` and keep as unsigned
- PSBT file status changes from `unsigned` to `signed` when complete

### Address Type Support

- **P2SH (Legacy multisig)**: ECDSA signature
- **P2SH-SegWit**: ECDSA signature with witness data
- **P2WSH (Native SegWit multisig)**: ECDSA signature with witness data
- **P2TR (Taproot script path)**: Schnorr signature (BIP340) with witness data
- Signature type automatically selected by btcd based on scriptPubKey

## Key Differences from Keygen Wallet

| Aspect | Keygen Wallet (#96) | Sign Wallet (#97) |
|--------|---------------------|-------------------|
| **Key Source** | accountKeyRepo (account_key table) | authKeyRepo (auth_account_key table) |
| **Input PSBT** | Unsigned (0 signatures) | Partially signed (1 signature) |
| **Output PSBT** | Partially signed (1 signature) | Fully signed (2 signatures) |
| **Role** | First signer | Second signer (completes multisig) |
| **Account Inference** | Infers from actionType | Not needed (auth key only) |
| **WIF Retrieval** | All account keys | Single auth key |

## Dependencies

This PR depends on:
- ✅ Issue #93: PSBT Infrastructure Layer (merged)
- ✅ Issue #94: Transaction File Repository PSBT Support (merged)
- ✅ Issue #96: Keygen Wallet PSBT Signing (merged in PR #105)

## Testing

All verification checks pass:

```bash
✅ make lint-fix      # Linting clean (0 issues)
✅ make check-build   # Build successful
✅ go test            # All tests pass
```

### Test Coverage

- Constructor tests verify use case instantiation and interface compliance
- Integration tests would require mocks for Bitcoin client and repositories
- See test file for comprehensive testing strategy documentation

## Files Modified

- `internal/application/usecase/sign/btc/sign_transaction.go` (143 insertions, 138 deletions)
- `internal/application/usecase/sign/btc/sign_transaction_test.go` (new file)

## Migration Notes

**Breaking Change**: This changes the transaction file format from CSV to PSBT.

- Old format: `{action}_{txID}_{txType}_{signedCount}_{timestamp}` (CSV with hex and metadata)
- New format: `{action}_{txID}_{txType}_{signedCount}_{timestamp}.psbt` (base64-encoded PSBT)

Users must ensure:
1. Watch wallet is updated (Issue #95) to generate PSBT files
2. Keygen wallet is updated (Issue #96) to sign PSBT files
3. Sign wallet uses this PR to complete PSBT signing
4. No mixing of old CSV files and new PSBT files

## Signature Flow Example

### 2-of-2 Multisig (Typical)

1. **Watch Wallet** (#95): Creates unsigned PSBT
   - File: `payment_5_unsigned_0_1534466246366489473.psbt`
   - Signatures: 0/2

2. **Keygen Wallet** (#96): Adds first signature
   - File: `payment_5_unsigned_1_1534466247000000000.psbt`
   - Signatures: 1/2

3. **Sign Wallet** (this PR): Adds second signature
   - File: `payment_5_signed_2_1534466248000000000.psbt`
   - Signatures: 2/2 ✓ Fully signed

4. **Watch Wallet** (#98): Finalizes and broadcasts

## Next Steps

- [ ] Issue #98: Watch Wallet - Implement PSBT Finalization and Broadcasting (Phase 2.7)

## Closes

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>