### PR TITLE
[PSBT Phase 2.7] Watch Wallet - Implement PSBT Finalization and Broadcasting (Issue #98)

### DIFF
--- a/internal/application/usecase/watch/btc/send_transaction_test.go
+++ b/internal/application/usecase/watch/btc/send_transaction_test.go
@@ -1,0 +1,106 @@
+package btc_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	watchusecase "github.com/hiromaily/go-crypto-wallet/internal/application/usecase/watch"
+	"github.com/hiromaily/go-crypto-wallet/internal/application/usecase/watch/btc"
+)
+
+// TestNewSendTransactionUseCase tests the constructor
+func TestNewSendTransactionUseCase(t *testing.T) {
+	t.Run("creates use case successfully with nil dependencies", func(t *testing.T) {
+		useCase := btc.NewSendTransactionUseCase(
+			nil, // btcClient
+			nil, // addrRepo
+			nil, // txRepo
+			nil, // txOutputRepo
+			nil, // txFileRepo
+		)
+
+		assert.NotNil(t, useCase, "use case should not be nil")
+	})
+
+	t.Run("returns correct interface type", func(t *testing.T) {
+		useCase := btc.NewSendTransactionUseCase(
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+		)
+
+		// Verify it implements the interface
+		assert.Implements(t, (*watchusecase.SendTransactionUseCase)(nil), useCase)
+	})
+}
+
+// Note: Full integration tests for SendTransactionUseCase would require:
+// 1. Mock Bitcoin client for:
+//    - IsPSBTComplete (validate fully signed PSBT)
+//    - FinalizePSBT (combine signatures)
+//    - ExtractTransaction (extract final transaction)
+//    - ToHex (convert to hex)
+//    - SendTransactionByHex (broadcast transaction)
+// 2. Mock transaction repository for database updates (UpdateAfterTxSent)
+// 3. Mock address repository for allocation updates (UpdateIsAllocated)
+// 4. Mock tx output repository for getting outputs (GetAllByTxID)
+// 5. Mock file repository for:
+//    - ValidateFilePath (extract metadata from file path)
+//    - ReadPSBTFile (read PSBT base64 from .psbt files)
+//    - ReadFile (read hex from legacy files)
+// 6. Fully signed PSBT files from Sign wallet output
+// 7. Proper cleanup after tests
+//
+// These would be better suited for integration tests rather than unit tests.
+// To enable proper unit testing, all dependencies should be mocked.
+//
+// Current test coverage focuses on:
+// - Constructor validation
+// - Interface compliance
+//
+// PSBT finalization and broadcasting functionality testing:
+// The Execute method now processes both PSBT and legacy hex files:
+//
+// PSBT Flow:
+// - Files with .psbt extension are detected automatically
+// - PSBT is validated to ensure it's fully signed (IsPSBTComplete)
+// - PSBT is finalized to combine signatures into final scriptSig/witness (FinalizePSBT)
+// - Final transaction is extracted from PSBT (ExtractTransaction)
+// - Transaction is converted to hex (ToHex)
+// - Transaction is broadcasted to Bitcoin network (SendTransactionByHex)
+// - Database is updated with sent transaction hash (UpdateAfterTxSent)
+// - Address allocation is updated for non-payment transactions (UpdateIsAllocated)
+//
+// Legacy Flow:
+// - Non-.psbt files are treated as legacy hex files
+// - Transaction hex is read directly from file (ReadFile)
+// - Transaction is broadcasted to Bitcoin network (SendTransactionByHex)
+// - Database is updated with sent transaction hash (UpdateAfterTxSent)
+// - Address allocation is updated for non-payment transactions (UpdateIsAllocated)
+//
+// Integration tests should verify:
+// - PSBT file reading (fully signed from Sign wallet)
+// - PSBT validation (detecting incomplete signatures)
+// - PSBT finalization (combining all signatures)
+// - Transaction extraction (converting PSBT to wire.MsgTx)
+// - Hex conversion (wire.MsgTx to hex string)
+// - Transaction broadcasting (sending to Bitcoin network)
+// - Database updates (btc_tx table with sent_tx_hash)
+// - Address allocation updates (for deposit/transfer transactions)
+// - Error handling for incomplete PSBTs
+// - Error handling for broadcast failures
+// - Error handling for database update failures
+// - Backward compatibility with legacy hex files
+// - Support for all multisig address types (P2SH, P2WSH, P2TR script path)
+//
+// End-to-end flow:
+// 1. Watch wallet creates unsigned PSBT (0 signatures)
+// 2. Keygen wallet adds first signature (1 signature)
+// 3. Sign wallet adds second signature (2 signatures, fully signed)
+// 4. Watch wallet finalizes, extracts, and broadcasts (Issue #98)
+// 5. Watch wallet updates database with sent transaction hash
+//
+// See docs/TESTING_STRATEGY.md for comprehensive testing approach.


### PR DESCRIPTION
## Summary
- Implements PSBT finalization and broadcasting for Watch wallet
- Completes the end-to-end PSBT signing flow (Phase 2.7)
- Adds support for both PSBT and legacy hex file formats
- Validates PSBT completeness before finalization
- Extracts and broadcasts final transactions to Bitcoin network

## Changes

### Core Implementation
- **File**: `internal/application/usecase/watch/btc/send_transaction.go`
  - Updated `Execute()` to detect file format (.psbt extension vs legacy)
  - Added `processPSBTFile()` method for PSBT finalization flow:
    - Validates PSBT is fully signed with `IsPSBTComplete()`
    - Finalizes PSBT to combine signatures with `FinalizePSBT()`
    - Extracts final transaction with `ExtractTransaction()`
    - Converts to hex for broadcasting with `ToHex()`
  - Added `isPSBTFile()` helper for format detection
  - Maintains backward compatibility with legacy hex files

### Test Coverage
- **File**: `internal/application/usecase/watch/btc/send_transaction_test.go` (NEW)
  - Constructor validation tests
  - Interface compliance verification
  - Comprehensive integration test documentation

## Complete PSBT Flow

1. **Watch wallet** creates unsigned PSBT (0 signatures) ✅ Issue #95
2. **Keygen wallet** adds first signature (1 signature) ✅ Issue #96
3. **Sign wallet** adds second signature (2 signatures) ✅ Issue #97
4. **Watch wallet** finalizes and broadcasts (this PR) ✅ Issue #98
5. Watch wallet updates database with sent transaction hash ✅

## Supported Features

- **Address Types**: P2SH, P2WSH, P2TR (Taproot script path)
- **Signature Algorithms**: ECDSA (legacy/SegWit), Schnorr (Taproot)
- **Transaction Types**: deposit, payment, transfer
- **Multisig**: 2-of-2 and 2-of-N configurations
- **Backward Compatibility**: Legacy hex file support maintained

## PSBT Finalization Process

```
PSBT File (fully signed)
        ↓
    Validate (IsPSBTComplete)
        ↓
    Finalize (FinalizePSBT)
        ↓
    Extract (ExtractTransaction)
        ↓
    Convert to Hex (ToHex)
        ↓
    Broadcast (SendTransactionByHex)
        ↓
    Update Database (UpdateAfterTxSent)
```

## Verification

- ✅ `make lint-fix` - 0 issues
- ✅ `make check-build` - All wallets build successfully
- ✅ `make gotest` - All tests pass

## Related Issues

- Closes #98
- Part of PSBT Phase 2 migration
- Follows #95, #96, #97

## Migration Notes

- PSBT files use `.psbt` extension for automatic detection
- Legacy hex files continue to work without changes
- Database schema unchanged
- Configuration unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)