### PR TITLE
Fix: Migrate TX & BTC transaction repositories to SQLC models (Closes #121)

### DIFF
--- a/internal/application/ports/persistence/repository.go
+++ b/internal/application/ports/persistence/repository.go
@@ -9,6 +9,7 @@ import (
 	domainAccount "github.com/hiromaily/go-crypto-wallet/internal/domain/account"
 	domainTx "github.com/hiromaily/go-crypto-wallet/internal/domain/transaction"
 	models "github.com/hiromaily/go-crypto-wallet/internal/infrastructure/database/models/rdb"
+	"github.com/hiromaily/go-crypto-wallet/internal/infrastructure/database/sqlc"
 	"github.com/hiromaily/go-crypto-wallet/internal/infrastructure/storage/file/address"
 )
 
@@ -76,12 +77,12 @@ type AddressRepositorier interface {
 
 // BTCTxRepositorier is BTCTxRepository interface
 type BTCTxRepositorier interface {
-	GetOne(id int64) (*models.BTCTX, error)
+	GetOne(id int64) (*sqlc.BtcTx, error)
 	GetCountByUnsignedHex(actionType domainTx.ActionType, hex string) (int64, error)
 	GetTxIDBySentHash(actionType domainTx.ActionType, hash string) (int64, error)
 	GetSentHashTx(actionType domainTx.ActionType, txType domainTx.TxType) ([]string, error)
-	InsertUnsignedTx(actionType domainTx.ActionType, txItem *models.BTCTX) (int64, error)
-	Update(txItem *models.BTCTX) (int64, error)
+	InsertUnsignedTx(actionType domainTx.ActionType, txItem *sqlc.BtcTx) (int64, error)
+	Update(txItem *sqlc.BtcTx) (int64, error)
 	UpdateAfterTxSent(txID int64, txType domainTx.TxType, signedHex, sentHashTx string) (int64, error)
 	UpdateTxType(id int64, txType domainTx.TxType) (int64, error)
 	UpdateTxTypeBySentHashTx(actionType domainTx.ActionType, txType domainTx.TxType, sentHashTx string) (int64, error)
@@ -90,26 +91,26 @@ type BTCTxRepositorier interface {
 
 // TxInputRepositorier is TxInputRepository interface
 type TxInputRepositorier interface {
-	GetOne(id int64) (*models.BTCTXInput, error)
-	GetAllByTxID(id int64) ([]*models.BTCTXInput, error)
-	Insert(txItem *models.BTCTXInput) error
-	InsertBulk(txItems []*models.BTCTXInput) error
+	GetOne(id int64) (*sqlc.BtcTxInput, error)
+	GetAllByTxID(id int64) ([]*sqlc.BtcTxInput, error)
+	Insert(txItem *sqlc.BtcTxInput) error
+	InsertBulk(txItems []*sqlc.BtcTxInput) error
 }
 
 // TxOutputRepositorier is TxOutputRepository interface
 type TxOutputRepositorier interface {
-	GetOne(id int64) (*models.BTCTXOutput, error)
-	GetAllByTxID(id int64) ([]*models.BTCTXOutput, error)
-	Insert(txItem *models.BTCTXOutput) error
-	InsertBulk(txItems []*models.BTCTXOutput) error
+	GetOne(id int64) (*sqlc.BtcTxOutput, error)
+	GetAllByTxID(id int64) ([]*sqlc.BtcTxOutput, error)
+	Insert(txItem *sqlc.BtcTxOutput) error
+	InsertBulk(txItems []*sqlc.BtcTxOutput) error
 }
 
 // TxRepositorier is TxRepository interface
 type TxRepositorier interface {
-	GetOne(id int64) (*models.TX, error)
+	GetOne(id int64) (*sqlc.Tx, error)
 	GetMaxID(actionType domainTx.ActionType) (int64, error)
 	InsertUnsignedTx(actionType domainTx.ActionType) (int64, error)
-	Update(txItem *models.TX) (int64, error)
+	Update(txItem *sqlc.Tx) (int64, error)
 	DeleteAll() (int64, error)
 }
 

--- a/internal/application/usecase/watch/btc/create_transaction.go
+++ b/internal/application/usecase/watch/btc/create_transaction.go
@@ -17,7 +17,7 @@ import (
 	domainWallet "github.com/hiromaily/go-crypto-wallet/internal/domain/wallet"
 	"github.com/hiromaily/go-crypto-wallet/internal/infrastructure/api/bitcoin"
 	"github.com/hiromaily/go-crypto-wallet/internal/infrastructure/api/bitcoin/btc"
-	models "github.com/hiromaily/go-crypto-wallet/internal/infrastructure/database/models/rdb"
+	"github.com/hiromaily/go-crypto-wallet/internal/infrastructure/database/sqlc"
 	watchrepo "github.com/hiromaily/go-crypto-wallet/internal/infrastructure/repository/watch"
 	"github.com/hiromaily/go-crypto-wallet/internal/infrastructure/storage/file"
 	"github.com/hiromaily/go-crypto-wallet/pkg/logger"
@@ -214,7 +214,7 @@ func (u *createTransactionUseCase) createTransferTx(
 
 type parsedTx struct {
 	txInputs       []btcjson.TransactionInput
-	txRepoTxInputs []*models.BTCTXInput
+	txRepoTxInputs []*sqlc.BtcTxInput
 	prevTxs        []btc.PrevTx
 	addresses      []string // input, sender's address
 }
@@ -396,7 +396,7 @@ func (u *createTransactionUseCase) parseListUnspentTx(
 ) (*parsedTx, btcutil.Amount, bool) {
 	var inputTotal btcutil.Amount
 	txInputs := make([]btcjson.TransactionInput, 0, len(unspentList))
-	txRepoTxInputs := make([]*models.BTCTXInput, 0, len(unspentList))
+	txRepoTxInputs := make([]*sqlc.BtcTxInput, 0, len(unspentList))
 	prevTxs := make([]btc.PrevTx, 0, len(unspentList))
 	addresses := make([]string, 0, len(unspentList))
 
@@ -429,13 +429,13 @@ func (u *createTransactionUseCase) parseListUnspentTx(
 			logger.Error("fail to convert input amount to decimal", "error", err)
 			continue
 		}
-		txRepoTxInputs = append(txRepoTxInputs, &models.BTCTXInput{
-			TXID:               0,
+		txRepoTxInputs = append(txRepoTxInputs, &sqlc.BtcTxInput{
+			TxID:               0,
 			InputTxid:          txItem.TxID,
 			InputVout:          txItem.Vout,
 			InputAddress:       txItem.Address,
 			InputAccount:       txItem.Label,
-			InputAmount:        inputAmount,
+			InputAmount:        inputAmount.String(),
 			InputConfirmations: uint64(txItem.Confirmations),
 		})
 
@@ -582,14 +582,14 @@ func (u *createTransactionUseCase) calculateOutputTotal(
 	adjustmentFee float64,
 	inputTotal btcutil.Amount,
 	txPrevOutputs map[btcutil.Address]btcutil.Amount,
-) (btcutil.Amount, btcutil.Amount, map[btcutil.Address]btcutil.Amount, []*models.BTCTXOutput, error) {
+) (btcutil.Amount, btcutil.Amount, map[btcutil.Address]btcutil.Amount, []*sqlc.BtcTxOutput, error) {
 	// get fee
 	fee, err := u.btcClient.GetFee(msgTx, adjustmentFee)
 	if err != nil {
 		return 0, 0, nil, nil, fmt.Errorf("fail to call btc.GetFee(): %w", err)
 	}
 	var outputTotal btcutil.Amount
-	txRepoOutputs := make([]*models.BTCTXOutput, 0, len(txPrevOutputs))
+	txRepoOutputs := make([]*sqlc.BtcTxOutput, 0, len(txPrevOutputs))
 
 	// subtract fee from output transaction for change
 	// FIXME: what if change is short, should re-run from the beginning with shortage-flag
@@ -601,11 +601,11 @@ func (u *createTransactionUseCase) calculateOutputTotal(
 			if err != nil {
 				return 0, 0, nil, nil, fmt.Errorf("fail to convert output amount to decimal: %w", err)
 			}
-			txRepoOutputs = append(txRepoOutputs, &models.BTCTXOutput{
-				TXID:          0,
+			txRepoOutputs = append(txRepoOutputs, &sqlc.BtcTxOutput{
+				TxID:          0,
 				OutputAddress: addr.String(),
 				OutputAccount: receiver.String(),
-				OutputAmount:  outputAmount,
+				OutputAmount:  outputAmount.String(),
 				IsChange:      false,
 			})
 			outputTotal += amt
@@ -620,11 +620,11 @@ func (u *createTransactionUseCase) calculateOutputTotal(
 			if err != nil {
 				return 0, 0, nil, nil, fmt.Errorf("fail to convert change amount to decimal: %w", err)
 			}
-			txRepoOutputs = append(txRepoOutputs, &models.BTCTXOutput{
-				TXID:          0,
+			txRepoOutputs = append(txRepoOutputs, &sqlc.BtcTxOutput{
+				TxID:          0,
 				OutputAddress: addr.String(),
 				OutputAccount: sender.String(),
-				OutputAmount:  outputAmount,
+				OutputAmount:  outputAmount.String(),
 				IsChange:      true,
 			})
 		} else {
@@ -632,11 +632,11 @@ func (u *createTransactionUseCase) calculateOutputTotal(
 			if err != nil {
 				return 0, 0, nil, nil, fmt.Errorf("fail to convert output amount to decimal: %w", err)
 			}
-			txRepoOutputs = append(txRepoOutputs, &models.BTCTXOutput{
-				TXID:          0,
+			txRepoOutputs = append(txRepoOutputs, &sqlc.BtcTxOutput{
+				TxID:          0,
 				OutputAddress: addr.String(),
 				OutputAccount: receiver.String(),
-				OutputAmount:  outputAmount,
+				OutputAmount:  outputAmount.String(),
 				IsChange:      false,
 			})
 		}
@@ -669,8 +669,8 @@ func (u *createTransactionUseCase) insertTxTableForUnsigned(
 	inputTotal,
 	outputTotal,
 	fee btcutil.Amount,
-	txInputs []*models.BTCTXInput,
-	txOutputs []*models.BTCTXOutput,
+	txInputs []*sqlc.BtcTxInput,
+	txOutputs []*sqlc.BtcTxOutput,
 	paymentRequestIds []int64,
 ) (int64, error) {
 	// skip if same hex is already stored
@@ -696,12 +696,12 @@ func (u *createTransactionUseCase) insertTxTableForUnsigned(
 	if err != nil {
 		return 0, fmt.Errorf("fail to convert fee amount to decimal: %w", err)
 	}
-	txItem := &models.BTCTX{
-		Action:            actionType.String(),
-		UnsignedHexTX:     hex,
-		TotalInputAmount:  totalInputAmt,
-		TotalOutputAmount: totalOutputAmt,
-		Fee:               feeAmt,
+	txItem := &sqlc.BtcTx{
+		Action:            sqlc.BtcTxAction(actionType.String()),
+		UnsignedHexTx:     hex,
+		TotalInputAmount:  totalInputAmt.String(),
+		TotalOutputAmount: totalOutputAmt.String(),
+		Fee:               feeAmt.String(),
 	}
 
 	// start database transaction
@@ -725,7 +725,7 @@ func (u *createTransactionUseCase) insertTxTableForUnsigned(
 	// TxReceiptInput table
 	//  update txID
 	for idx := range txInputs {
-		txInputs[idx].TXID = txID
+		txInputs[idx].TxID = txID
 	}
 	err = u.txInputRepo.InsertBulk(txInputs)
 	if err != nil {
@@ -735,7 +735,7 @@ func (u *createTransactionUseCase) insertTxTableForUnsigned(
 	// TxReceiptOutput table
 	//  update txID
 	for idx := range txOutputs {
-		txOutputs[idx].TXID = txID
+		txOutputs[idx].TxID = txID
 	}
 	err = u.txOutputRepo.InsertBulk(txOutputs)
 	if err != nil {

--- a/internal/infrastructure/repository/watch/btc_tx_input_sqlc.go
+++ b/internal/infrastructure/repository/watch/btc_tx_input_sqlc.go
@@ -5,10 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/quagmt/udecimal"
-
 	domainCoin "github.com/hiromaily/go-crypto-wallet/internal/domain/coin"
-	models "github.com/hiromaily/go-crypto-wallet/internal/infrastructure/database/models/rdb"
 	"github.com/hiromaily/go-crypto-wallet/internal/infrastructure/database/sqlc"
 )
 
@@ -29,7 +26,7 @@ func NewBTCTxInputRepositorySqlc(
 }
 
 // GetOne get one record by ID
-func (r *TxInputRepositorySqlc) GetOne(id int64) (*models.BTCTXInput, error) {
+func (r *TxInputRepositorySqlc) GetOne(id int64) (*sqlc.BtcTxInput, error) {
 	ctx := context.Background()
 
 	input, err := r.queries.GetBtcTxInputByID(ctx, id)
@@ -37,11 +34,11 @@ func (r *TxInputRepositorySqlc) GetOne(id int64) (*models.BTCTXInput, error) {
 		return nil, fmt.Errorf("failed to call GetBtcTxInputByID(): %w", err)
 	}
 
-	return convertSqlcBtcTxInputToModel(&input), nil
+	return &input, nil
 }
 
 // GetAllByTxID returns all records searched by tx_id
-func (r *TxInputRepositorySqlc) GetAllByTxID(id int64) ([]*models.BTCTXInput, error) {
+func (r *TxInputRepositorySqlc) GetAllByTxID(id int64) ([]*sqlc.BtcTxInput, error) {
 	ctx := context.Background()
 
 	inputs, err := r.queries.GetBtcTxInputsByTxID(ctx, id)
@@ -49,27 +46,27 @@ func (r *TxInputRepositorySqlc) GetAllByTxID(id int64) ([]*models.BTCTXInput, er
 		return nil, fmt.Errorf("failed to call GetBtcTxInputsByTxID(): %w", err)
 	}
 
-	result := make([]*models.BTCTXInput, len(inputs))
-	for i, input := range inputs {
-		result[i] = convertSqlcBtcTxInputToModel(&input)
+	result := make([]*sqlc.BtcTxInput, len(inputs))
+	for i := range inputs {
+		result[i] = &inputs[i]
 	}
 
 	return result, nil
 }
 
 // Insert inserts one record
-func (r *TxInputRepositorySqlc) Insert(txItem *models.BTCTXInput) error {
+func (r *TxInputRepositorySqlc) Insert(txItem *sqlc.BtcTxInput) error {
 	ctx := context.Background()
 
 	_, err := r.queries.InsertBtcTxInput(ctx, sqlc.InsertBtcTxInputParams{
-		TxID:               txItem.TXID,
+		TxID:               txItem.TxID,
 		InputTxid:          txItem.InputTxid,
 		InputVout:          txItem.InputVout,
 		InputAddress:       txItem.InputAddress,
 		InputAccount:       txItem.InputAccount,
-		InputAmount:        txItem.InputAmount.String(),
+		InputAmount:        txItem.InputAmount,
 		InputConfirmations: txItem.InputConfirmations,
-		UpdatedAt:          convertNullTimeToSQLNullTime(txItem.UpdatedAt),
+		UpdatedAt:          txItem.UpdatedAt,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to call InsertBtcTxInput(): %w", err)
@@ -79,29 +76,11 @@ func (r *TxInputRepositorySqlc) Insert(txItem *models.BTCTXInput) error {
 }
 
 // InsertBulk inserts multiple records
-func (r *TxInputRepositorySqlc) InsertBulk(txItems []*models.BTCTXInput) error {
+func (r *TxInputRepositorySqlc) InsertBulk(txItems []*sqlc.BtcTxInput) error {
 	for _, item := range txItems {
 		if err := r.Insert(item); err != nil {
 			return err
 		}
 	}
 	return nil
-}
-
-// Helper functions
-
-func convertSqlcBtcTxInputToModel(input *sqlc.BtcTxInput) *models.BTCTXInput {
-	amount, _ := udecimal.Parse(input.InputAmount)
-
-	return &models.BTCTXInput{
-		ID:                 input.ID,
-		TXID:               input.TxID,
-		InputTxid:          input.InputTxid,
-		InputVout:          input.InputVout,
-		InputAddress:       input.InputAddress,
-		InputAccount:       input.InputAccount,
-		InputAmount:        amount,
-		InputConfirmations: input.InputConfirmations,
-		UpdatedAt:          convertSQLNullTimeToNullTime(input.UpdatedAt),
-	}
 }

--- a/internal/infrastructure/repository/watch/btc_tx_output_sqlc.go
+++ b/internal/infrastructure/repository/watch/btc_tx_output_sqlc.go
@@ -5,10 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/quagmt/udecimal"
-
 	domainCoin "github.com/hiromaily/go-crypto-wallet/internal/domain/coin"
-	models "github.com/hiromaily/go-crypto-wallet/internal/infrastructure/database/models/rdb"
 	"github.com/hiromaily/go-crypto-wallet/internal/infrastructure/database/sqlc"
 )
 
@@ -29,7 +26,7 @@ func NewBTCTxOutputRepositorySqlc(
 }
 
 // GetOne get one record by ID
-func (r *TxOutputRepositorySqlc) GetOne(id int64) (*models.BTCTXOutput, error) {
+func (r *TxOutputRepositorySqlc) GetOne(id int64) (*sqlc.BtcTxOutput, error) {
 	ctx := context.Background()
 
 	output, err := r.queries.GetBtcTxOutputByID(ctx, id)
@@ -37,11 +34,11 @@ func (r *TxOutputRepositorySqlc) GetOne(id int64) (*models.BTCTXOutput, error) {
 		return nil, fmt.Errorf("failed to call GetBtcTxOutputByID(): %w", err)
 	}
 
-	return convertSqlcBtcTxOutputToModel(&output), nil
+	return &output, nil
 }
 
 // GetAllByTxID returns all records searched by tx_id
-func (r *TxOutputRepositorySqlc) GetAllByTxID(id int64) ([]*models.BTCTXOutput, error) {
+func (r *TxOutputRepositorySqlc) GetAllByTxID(id int64) ([]*sqlc.BtcTxOutput, error) {
 	ctx := context.Background()
 
 	outputs, err := r.queries.GetBtcTxOutputsByTxID(ctx, id)
@@ -49,25 +46,25 @@ func (r *TxOutputRepositorySqlc) GetAllByTxID(id int64) ([]*models.BTCTXOutput, 
 		return nil, fmt.Errorf("failed to call GetBtcTxOutputsByTxID(): %w", err)
 	}
 
-	result := make([]*models.BTCTXOutput, len(outputs))
-	for i, output := range outputs {
-		result[i] = convertSqlcBtcTxOutputToModel(&output)
+	result := make([]*sqlc.BtcTxOutput, len(outputs))
+	for i := range outputs {
+		result[i] = &outputs[i]
 	}
 
 	return result, nil
 }
 
 // Insert inserts one record
-func (r *TxOutputRepositorySqlc) Insert(txItem *models.BTCTXOutput) error {
+func (r *TxOutputRepositorySqlc) Insert(txItem *sqlc.BtcTxOutput) error {
 	ctx := context.Background()
 
 	_, err := r.queries.InsertBtcTxOutput(ctx, sqlc.InsertBtcTxOutputParams{
-		TxID:          txItem.TXID,
+		TxID:          txItem.TxID,
 		OutputAddress: txItem.OutputAddress,
 		OutputAccount: txItem.OutputAccount,
-		OutputAmount:  txItem.OutputAmount.String(),
+		OutputAmount:  txItem.OutputAmount,
 		IsChange:      txItem.IsChange,
-		UpdatedAt:     convertNullTimeToSQLNullTime(txItem.UpdatedAt),
+		UpdatedAt:     txItem.UpdatedAt,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to call InsertBtcTxOutput(): %w", err)
@@ -77,27 +74,11 @@ func (r *TxOutputRepositorySqlc) Insert(txItem *models.BTCTXOutput) error {
 }
 
 // InsertBulk inserts multiple records
-func (r *TxOutputRepositorySqlc) InsertBulk(txItems []*models.BTCTXOutput) error {
+func (r *TxOutputRepositorySqlc) InsertBulk(txItems []*sqlc.BtcTxOutput) error {
 	for _, item := range txItems {
 		if err := r.Insert(item); err != nil {
 			return err
 		}
 	}
 	return nil
-}
-
-// Helper functions
-
-func convertSqlcBtcTxOutputToModel(output *sqlc.BtcTxOutput) *models.BTCTXOutput {
-	amount, _ := udecimal.Parse(output.OutputAmount)
-
-	return &models.BTCTXOutput{
-		ID:            output.ID,
-		TXID:          output.TxID,
-		OutputAddress: output.OutputAddress,
-		OutputAccount: output.OutputAccount,
-		OutputAmount:  amount,
-		IsChange:      output.IsChange,
-		UpdatedAt:     convertSQLNullTimeToNullTime(output.UpdatedAt),
-	}
 }

--- a/internal/infrastructure/repository/watch/btc_tx_sqlc.go
+++ b/internal/infrastructure/repository/watch/btc_tx_sqlc.go
@@ -6,11 +6,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/quagmt/udecimal"
-
 	domainCoin "github.com/hiromaily/go-crypto-wallet/internal/domain/coin"
 	domainTx "github.com/hiromaily/go-crypto-wallet/internal/domain/transaction"
-	models "github.com/hiromaily/go-crypto-wallet/internal/infrastructure/database/models/rdb"
 	"github.com/hiromaily/go-crypto-wallet/internal/infrastructure/database/sqlc"
 )
 
@@ -29,7 +26,7 @@ func NewBTCTxRepositorySqlc(dbConn *sql.DB, coinTypeCode domainCoin.CoinTypeCode
 }
 
 // GetOne returns one record by ID
-func (r *BTCTxRepositorySqlc) GetOne(id int64) (*models.BTCTX, error) {
+func (r *BTCTxRepositorySqlc) GetOne(id int64) (*sqlc.BtcTx, error) {
 	ctx := context.Background()
 
 	btcTx, err := r.queries.GetBtcTxByID(ctx, id)
@@ -37,7 +34,7 @@ func (r *BTCTxRepositorySqlc) GetOne(id int64) (*models.BTCTX, error) {
 		return nil, fmt.Errorf("failed to call GetBtcTxByID(): %w", err)
 	}
 
-	return convertSqlcBtcTxToModel(&btcTx), nil
+	return &btcTx, nil
 }
 
 // GetCountByUnsignedHex returns count by hex string
@@ -89,21 +86,21 @@ func (r *BTCTxRepositorySqlc) GetSentHashTx(actionType domainTx.ActionType, txTy
 }
 
 // InsertUnsignedTx inserts records
-func (r *BTCTxRepositorySqlc) InsertUnsignedTx(actionType domainTx.ActionType, txItem *models.BTCTX) (int64, error) {
+func (r *BTCTxRepositorySqlc) InsertUnsignedTx(actionType domainTx.ActionType, txItem *sqlc.BtcTx) (int64, error) {
 	ctx := context.Background()
 
 	result, err := r.queries.InsertBtcTx(ctx, sqlc.InsertBtcTxParams{
 		Coin:              sqlc.BtcTxCoin(r.coinTypeCode.String()),
 		Action:            sqlc.BtcTxAction(actionType.String()),
-		UnsignedHexTx:     txItem.UnsignedHexTX,
-		SignedHexTx:       txItem.SignedHexTX,
-		SentHashTx:        txItem.SentHashTX,
-		TotalInputAmount:  txItem.TotalInputAmount.String(),
-		TotalOutputAmount: txItem.TotalOutputAmount.String(),
-		Fee:               txItem.Fee.String(),
-		CurrentTxType:     txItem.CurrentTXType,
-		UnsignedUpdatedAt: convertNullTimeToSQLNullTime(txItem.UnsignedUpdatedAt),
-		SentUpdatedAt:     convertNullTimeToSQLNullTime(txItem.SentUpdatedAt),
+		UnsignedHexTx:     txItem.UnsignedHexTx,
+		SignedHexTx:       txItem.SignedHexTx,
+		SentHashTx:        txItem.SentHashTx,
+		TotalInputAmount:  txItem.TotalInputAmount,
+		TotalOutputAmount: txItem.TotalOutputAmount,
+		Fee:               txItem.Fee,
+		CurrentTxType:     txItem.CurrentTxType,
+		UnsignedUpdatedAt: txItem.UnsignedUpdatedAt,
+		SentUpdatedAt:     txItem.SentUpdatedAt,
 	})
 	if err != nil {
 		return 0, fmt.Errorf("failed to call InsertBtcTx(): %w", err)
@@ -117,22 +114,22 @@ func (r *BTCTxRepositorySqlc) InsertUnsignedTx(actionType domainTx.ActionType, t
 	return id, nil
 }
 
-// Update updates by models.BTCTX (entire update)
-func (r *BTCTxRepositorySqlc) Update(txItem *models.BTCTX) (int64, error) {
+// Update updates by sqlc.BtcTx (entire update)
+func (r *BTCTxRepositorySqlc) Update(txItem *sqlc.BtcTx) (int64, error) {
 	ctx := context.Background()
 
 	err := r.queries.UpdateBtcTx(ctx, sqlc.UpdateBtcTxParams{
-		Coin:              sqlc.BtcTxCoin(txItem.Coin),
-		Action:            sqlc.BtcTxAction(txItem.Action),
-		UnsignedHexTx:     txItem.UnsignedHexTX,
-		SignedHexTx:       txItem.SignedHexTX,
-		SentHashTx:        txItem.SentHashTX,
-		TotalInputAmount:  txItem.TotalInputAmount.String(),
-		TotalOutputAmount: txItem.TotalOutputAmount.String(),
-		Fee:               txItem.Fee.String(),
-		CurrentTxType:     txItem.CurrentTXType,
-		UnsignedUpdatedAt: convertNullTimeToSQLNullTime(txItem.UnsignedUpdatedAt),
-		SentUpdatedAt:     convertNullTimeToSQLNullTime(txItem.SentUpdatedAt),
+		Coin:              txItem.Coin,
+		Action:            txItem.Action,
+		UnsignedHexTx:     txItem.UnsignedHexTx,
+		SignedHexTx:       txItem.SignedHexTx,
+		SentHashTx:        txItem.SentHashTx,
+		TotalInputAmount:  txItem.TotalInputAmount,
+		TotalOutputAmount: txItem.TotalOutputAmount,
+		Fee:               txItem.Fee,
+		CurrentTxType:     txItem.CurrentTxType,
+		UnsignedUpdatedAt: txItem.UnsignedUpdatedAt,
+		SentUpdatedAt:     txItem.SentUpdatedAt,
 		ID:                txItem.ID,
 	})
 	if err != nil {
@@ -229,27 +226,4 @@ func (r *BTCTxRepositorySqlc) DeleteAll() (int64, error) {
 	}
 
 	return rowsAffected, nil
-}
-
-// Helper functions
-
-func convertSqlcBtcTxToModel(btcTx *sqlc.BtcTx) *models.BTCTX {
-	totalInputAmount, _ := udecimal.Parse(btcTx.TotalInputAmount)
-	totalOutputAmount, _ := udecimal.Parse(btcTx.TotalOutputAmount)
-	fee, _ := udecimal.Parse(btcTx.Fee)
-
-	return &models.BTCTX{
-		ID:                btcTx.ID,
-		Coin:              string(btcTx.Coin),
-		Action:            string(btcTx.Action),
-		UnsignedHexTX:     btcTx.UnsignedHexTx,
-		SignedHexTX:       btcTx.SignedHexTx,
-		SentHashTX:        btcTx.SentHashTx,
-		TotalInputAmount:  totalInputAmount,
-		TotalOutputAmount: totalOutputAmount,
-		Fee:               fee,
-		CurrentTXType:     btcTx.CurrentTxType,
-		UnsignedUpdatedAt: convertSQLNullTimeToNullTime(btcTx.UnsignedUpdatedAt),
-		SentUpdatedAt:     convertSQLNullTimeToNullTime(btcTx.SentUpdatedAt),
-	}
 }

--- a/internal/infrastructure/repository/watch/tx_sqlc.go
+++ b/internal/infrastructure/repository/watch/tx_sqlc.go
@@ -7,7 +7,6 @@ import (
 
 	domainCoin "github.com/hiromaily/go-crypto-wallet/internal/domain/coin"
 	domainTx "github.com/hiromaily/go-crypto-wallet/internal/domain/transaction"
-	models "github.com/hiromaily/go-crypto-wallet/internal/infrastructure/database/models/rdb"
 	"github.com/hiromaily/go-crypto-wallet/internal/infrastructure/database/sqlc"
 )
 
@@ -26,7 +25,7 @@ func NewTxRepositorySqlc(dbConn *sql.DB, coinTypeCode domainCoin.CoinTypeCode) *
 }
 
 // GetOne returns one record by ID
-func (r *TxRepositorySqlc) GetOne(id int64) (*models.TX, error) {
+func (r *TxRepositorySqlc) GetOne(id int64) (*sqlc.Tx, error) {
 	ctx := context.Background()
 
 	tx, err := r.queries.GetTxByID(ctx, id)
@@ -34,7 +33,7 @@ func (r *TxRepositorySqlc) GetOne(id int64) (*models.TX, error) {
 		return nil, fmt.Errorf("failed to call GetTxByID(): %w", err)
 	}
 
-	return convertSqlcTxToModel(&tx), nil
+	return &tx, nil
 }
 
 // GetMaxID returns max id
@@ -81,14 +80,14 @@ func (r *TxRepositorySqlc) InsertUnsignedTx(actionType domainTx.ActionType) (int
 	return id, nil
 }
 
-// Update updates by models.Tx (entire update)
-func (r *TxRepositorySqlc) Update(txItem *models.TX) (int64, error) {
+// Update updates by sqlc.Tx (entire update)
+func (r *TxRepositorySqlc) Update(txItem *sqlc.Tx) (int64, error) {
 	ctx := context.Background()
 
 	err := r.queries.UpdateTx(ctx, sqlc.UpdateTxParams{
-		Coin:      sqlc.TxCoin(txItem.Coin),
-		Action:    sqlc.TxAction(txItem.Action),
-		UpdatedAt: convertNullTimeToSQLNullTime(txItem.UpdatedAt),
+		Coin:      txItem.Coin,
+		Action:    txItem.Action,
+		UpdatedAt: txItem.UpdatedAt,
 		ID:        txItem.ID,
 	})
 	if err != nil {
@@ -113,15 +112,4 @@ func (r *TxRepositorySqlc) DeleteAll() (int64, error) {
 	}
 
 	return rowsAffected, nil
-}
-
-// Helper functions
-
-func convertSqlcTxToModel(tx *sqlc.Tx) *models.TX {
-	return &models.TX{
-		ID:        tx.ID,
-		Coin:      string(tx.Coin),
-		Action:    string(tx.Action),
-		UpdatedAt: convertSQLNullTimeToNullTime(tx.UpdatedAt),
-	}
 }


### PR DESCRIPTION
## Summary

This PR migrates four transaction-related repositories from using manually cleaned SQLBoiler models to auto-generated SQLC models, continuing the SQLBoiler → SQLC migration effort.

## Changes

### Repository Layer (4 interfaces, 4 implementations)

**Interface Updates (`repository.go`):**
- `TxRepositorier`: `*models.TX` → `*sqlc.Tx`
- `BTCTxRepositorier`: `*models.BTCTX` → `*sqlc.BtcTx`
- `TxInputRepositorier`: `*models.BTCTXInput` → `*sqlc.BtcTxInput`
- `TxOutputRepositorier`: `*models.BTCTXOutput` → `*sqlc.BtcTxOutput`

**Implementation Updates:**
- **`tx_sqlc.go`**: Removed conversion function (~7 lines), direct sqlc returns
- **`btc_tx_sqlc.go`**: Removed conversion function (~19 lines), fixed decimal handling
- **`btc_tx_input_sqlc.go`**: Removed conversion function (~15 lines)
- **`btc_tx_output_sqlc.go`**: Removed conversion function (~13 lines)

### Use Case Layer

**`create_transaction.go` (BTC transaction creation):**
- Added sqlc import, removed models import
- Updated field names: `TXID` → `TxID`, `UnsignedHexTX` → `UnsignedHexTx`
- Added decimal to string conversions: `inputAmount.String()`, `outputAmount.String()`
- Added enum casting: `sqlc.BtcTxAction(actionType.String())`

## Technical Details

### Type Changes

1. **Enum Types**:
   - Old: `Coin string`, `Action string`
   - New: `Coin BtcTxCoin`, `Action BtcTxAction` (typed enums)
   - Requires explicit casting: `sqlc.BtcTxCoin(coinCode.String())`

2. **Decimal Types**:
   - Old: `TotalInputAmount udecimal.Decimal`, `Fee udecimal.Decimal`
   - New: `TotalInputAmount string`, `Fee string`
   - Conversion: `amount.String()` when creating models
   - Critical for financial accuracy in BTC transactions

3. **Field Naming**:
   - Old: `TXID`, `UnsignedHexTX` (all caps or inconsistent)
   - New: `TxID`, `UnsignedHexTx` (proper camelCase)

4. **Direct Returns**:
   - Eliminated conversion layer between SQLC queries and repository returns
   - Reduced code by removing bidirectional conversion functions

## Impact

- **Files Changed**: 6 files
- **Net Reduction**: 77 lines (-172 deletions, +95 insertions)
- **Conversion Functions Removed**: 4 functions (~54 lines total)
- **Critical Path**: BTC/BCH transaction creation and management

## Testing

All verification commands passed:
- ✅ `make lint-fix` - 0 issues
- ✅ `make tidy` - Dependencies organized
- ✅ `make check-build` - All binaries built successfully (watch, keygen, sign)
- ✅ `make gotest` - All tests passed

## Related Issues

Part of parent issue #116 (SQLBoiler to SQLC migration)
- Previous: #120 (Sub-issue 4 - Address Repository)
- **Closes**: #121 (Sub-issue 5 - TX & BTCTX Repositories)
- Next: Sub-issue 6 (ETH & XRP Transaction Repositories)

## Next Steps

Continue migration with remaining repositories:
- #122: ETH and XRP detail transaction repositories
- #123: PaymentRequest repository  
- #124: Final cleanup and verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)