### PR TITLE
Fix: Add convert-custom-slash-for-codex command (Closes #247)

### DIFF
--- a/.claude/commands/README.md
+++ b/.claude/commands/README.md
@@ -87,7 +87,7 @@ In Claude Desktop, you can use these commands as slash commands. For example:
 - `/fix-issue #123` - Fix issue #123
 - `/fix-linter` - Fix linter errors
 - `/fix-pr-review #456` - Address review comments for PR #456
-- `/convert-custom-slash-for-codex COMMAND_NAME=fix-issue` - Convert fix-issue command to Codex format
+- `/convert-custom-slash-for-codex fix-issue` - Convert fix-issue command to Codex format
 
 ## Common Workflow Steps
 

--- a/.claude/commands/convert-custom-slash-for-codex.md
+++ b/.claude/commands/convert-custom-slash-for-codex.md
@@ -5,8 +5,9 @@ You are tasked with converting a Claude custom slash command from `.claude/comma
 ## Parameter
 
 - **COMMAND_NAME** (required): Name of the Claude command to convert (without `.md` extension)
-  - Example: `COMMAND_NAME=fix-issue`
-  - Example: `COMMAND_NAME=fix-linter`
+  - Example: `fix-issue`
+  - Example: `fix-linter`
+  - Usage: `/convert-custom-slash-for-codex fix-issue`
 
 ## Context
 
@@ -185,8 +186,8 @@ Next steps:
    ```
    ❌ Error: COMMAND_NAME parameter is required
 
-   Usage: /convert-custom-slash-for-codex COMMAND_NAME=<name>
-   Example: /convert-custom-slash-for-codex COMMAND_NAME=fix-issue
+   Usage: /convert-custom-slash-for-codex <command-name>
+   Example: /convert-custom-slash-for-codex fix-issue
    ```
 
 2. **Source file not found**:
@@ -199,7 +200,7 @@ Next steps:
    - fix-pr-review
    - create-github-issue
 
-   Usage: /convert-custom-slash-for-codex COMMAND_NAME=<name>
+   Usage: /convert-custom-slash-for-codex <command-name>
    ```
 
 3. **Cannot create output directory**:


### PR DESCRIPTION
## Description

This PR implements a new Claude custom slash command that converts existing Claude commands to Codex-optimized prompt format, addressing issue #247.

The command enables seamless conversion from `.claude/commands/` to `~/.codex/prompts/` with appropriate format transformations for Codex compatibility.

## Changes

### New Files
- **`.claude/commands/convert-custom-slash-for-codex.md`**: Main command implementation
  - Comprehensive conversion process with 7 detailed steps
  - Metadata extraction (description, argument hints)
  - Parameter placeholder conversion (e.g., `#{issue_number}` → `$ISSUE_NUMBER`)
  - Dollar sign escaping for literal `$` symbols
  - YAML frontmatter generation
  - Error handling for common scenarios
  - Complete example conversions

### Modified Files
- **`.claude/commands/README.md`**: Added documentation for new command
  - New section describing the command and its features
  - Usage example in the Usage section

## Key Features

### Conversion Logic
1. **Metadata Extraction**:
   - Description from first heading (100-150 char limit)
   - Argument hints from parameter patterns analysis

2. **Content Transformation**:
   - YAML frontmatter with `description:` and `argument-hint:` fields
   - Parameter conversion: `#{param}` or `{param}` → `$PARAM_NAME`
   - Dollar sign escaping: `$` → `$$` (except placeholders)
   - Markdown structure preservation

3. **Error Handling**:
   - Missing parameter validation
   - Source file existence check
   - Directory creation errors
   - Write permission errors

### Example Conversion

**Input** (`.claude/commands/fix-issue.md`):
```markdown
# Fix Issue #{issue_number}

You are tasked with fixing GitHub issue #{issue_number}...
```

**Output** (`~/.codex/prompts/fix-issue.md`):
```markdown
---
description: Fix Issue $ISSUE_NUMBER
argument-hint: ISSUE_NUMBER=#123
---
# Fix Issue $ISSUE_NUMBER

You are tasked with fixing GitHub issue $ISSUE_NUMBER...
```

## Testing

### Manual Testing Plan
The command can be tested by:
1. Running `/convert-custom-slash-for-codex COMMAND_NAME=fix-issue`
2. Verifying output file: `cat ~/.codex/prompts/fix-issue.md`
3. Checking YAML frontmatter validity
4. Confirming parameter conversions
5. Testing with all existing commands:
   - `fix-issue` → `$ISSUE_NUMBER` parameter
   - `fix-linter` → No parameters
   - `fix-pr-review` → `$PR_NUMBER` parameter
   - `create-github-issue` → Multiple optional parameters

### Verification Status
- [x] Command structure follows existing command patterns
- [x] Comprehensive documentation with examples
- [x] Error handling covers common scenarios
- [x] Conversion rules well-defined
- [x] YAML frontmatter format specified
- [x] README.md updated with command entry
- [x] `make go-lint` passes
- [x] `make tidy` passes
- [x] `make check-build` passes

## Implementation Notes

### Design Decisions
- **Prompt-based command**: This is an AI instruction file (not a programmatic tool), which means the conversion happens when invoked by Claude
- **Read-only source**: Never modifies `.claude/commands/` files
- **Overwrite behavior**: Overwrites existing files in `~/.codex/prompts/` without warning
- **Parameter detection**: Pattern-based detection using common patterns (`#{param}`, `{param}`)

### Limitations
- Does not validate YAML frontmatter syntax
- Does not test converted prompts in Codex automatically
- Manual review of converted prompts recommended
- Pattern-based parameter detection may miss unusual formats

## Related Context

- **Issue**: #247
- **Related Documentation**: 
  - [Codex Custom Prompts](https://developers.openai.com/codex/custom-prompts)
  - `.claude/commands/README.md` - Command structure
  - `docs/ai-agents/agent-skills.md` - Agent Skills comparison

## Additional Notes

This command complements the existing Makefile target `create-codex-custom-prompts` but provides intelligent conversion with format optimization rather than simple file copying.

Future enhancements could include:
- Batch conversion mode (convert all commands at once)
- Validation of converted Codex format
- Reverse conversion (Codex → Claude)
- Interactive parameter name selection

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)