### PR TITLE
Fix: Sub-issue #176.6: Descriptor Generation Use Case (Closes 182)

### DIFF
--- a/internal/application/usecase/keygen/btc/generate_descriptor.go
+++ b/internal/application/usecase/keygen/btc/generate_descriptor.go
@@ -47,7 +47,7 @@ func (u *generateDescriptorUseCase) Generate(
 ) (keygenusecase.GenerateDescriptorOutput, error) {
 	_ = ctx
 
-	isMultisig := u.multisigConfig != nil && u.multisigConfig.IsMultisigAccount(input.AccountType)
+	isMultisig := u.multisigConfig.IsMultisigAccount(input.AccountType)
 
 	var (
 		descriptor string
@@ -115,16 +115,15 @@ func (u *generateDescriptorUseCase) generateSingleSigDescriptor(
 func (u *generateDescriptorUseCase) generateMultisigDescriptor(
 	input keygenusecase.GenerateDescriptorInput,
 ) (string, error) {
-	if u.multisigConfig == nil {
-		return "", fmt.Errorf("multisig config not available for %s", input.AccountType.String())
-	}
-
 	multiConfig := u.multisigConfig.MultiAccounts()[input.AccountType]
 	if len(multiConfig) == 0 {
 		return "", fmt.Errorf("multisig account not configured for %s", input.AccountType.String())
 	}
 
-	requiredSigs, authTypes := firstRequiredSigConfig(multiConfig)
+	requiredSigs, authTypes, err := selectRequiredSigConfig(multiConfig, input.RequiredSigs)
+	if err != nil {
+		return "", err
+	}
 
 	signers, err := u.buildMultisigSigners(authTypes, input.AddressType)
 	if err != nil {
@@ -208,11 +207,20 @@ func derivationPathForAddress(addrType domainAddress.AddrType, isMultisig bool) 
 	}
 }
 
-func firstRequiredSigConfig(config map[int][]domainAccount.AuthType) (int, []domainAccount.AuthType) {
+func selectRequiredSigConfig(config map[int][]domainAccount.AuthType, requested int) (int, []domainAccount.AuthType, error) {
 	if len(config) == 0 {
-		return 0, nil
+		return 0, nil, fmt.Errorf("no multisig configuration available")
 	}
 
+	if requested > 0 {
+		auths, ok := config[requested]
+		if !ok {
+			return 0, nil, fmt.Errorf("required signatures %d not configured", requested)
+		}
+		return requested, auths, nil
+	}
+
+	// Default to the smallest required-sigs configuration if not specified.
 	requiredKeys := make([]int, 0, len(config))
 	for k := range config {
 		requiredKeys = append(requiredKeys, k)
@@ -220,5 +228,5 @@ func firstRequiredSigConfig(config map[int][]domainAccount.AuthType) (int, []dom
 	sort.Ints(requiredKeys)
 
 	req := requiredKeys[0]
-	return req, config[req]
+	return req, config[req], nil
 }

--- a/internal/application/usecase/keygen/btc/generate_descriptor_test.go
+++ b/internal/application/usecase/keygen/btc/generate_descriptor_test.go
@@ -111,9 +111,10 @@ func TestGenerateDescriptorUseCase_MultisigWsh(t *testing.T) {
 	require.NoError(t, err)
 
 	output, err := useCase.Generate(context.Background(), keygenusecase.GenerateDescriptorInput{
-		AccountType: domainAccount.AccountTypeDeposit,
-		AddressType: domainAddress.AddrTypeBech32,
-		IsChange:    false,
+		AccountType:  domainAccount.AccountTypeDeposit,
+		AddressType:  domainAddress.AddrTypeBech32,
+		IsChange:     false,
+		RequiredSigs: 2,
 	})
 	require.NoError(t, err)
 	require.True(t, output.IsMultisig)
@@ -142,15 +143,30 @@ func TestGenerateDescriptorUseCase_TaprootScriptPath(t *testing.T) {
 		multiConfig,
 	)
 
+	fp1, err := infraKey.FingerprintFromExtendedKey(signers[domainAccount.AuthType1].FullPublicKey)
+	require.NoError(t, err)
+	fp2, err := infraKey.FingerprintFromExtendedKey(signers[domainAccount.AuthType2].FullPublicKey)
+	require.NoError(t, err)
+
 	output, err := useCase.Generate(context.Background(), keygenusecase.GenerateDescriptorInput{
-		AccountType: domainAccount.AccountTypeDeposit,
-		AddressType: domainAddress.AddrTypeTaproot,
-		IsChange:    false,
+		AccountType:  domainAccount.AccountTypeDeposit,
+		AddressType:  domainAddress.AddrTypeTaproot,
+		IsChange:     false,
+		RequiredSigs: 2,
 	})
 	require.NoError(t, err)
 	require.True(t, output.IsMultisig)
-	require.Contains(t, output.Descriptor, "tr([")
-	require.Contains(t, output.Descriptor, "/0/*)")
+	xpub1, _ := hdkeychain.NewKeyFromString(signers[domainAccount.AuthType1].FullPublicKey)
+	xpub2, _ := hdkeychain.NewKeyFromString(signers[domainAccount.AuthType2].FullPublicKey)
+	expected, err := btc.NewDescriptorService(&chaincfg.MainNetParams).GenerateTaprootScriptPathDescriptor(
+		[]btc.MultisigSigner{
+			{Fingerprint: fp1.String(), DerivationPath: "/86'/0'/0'", ExtendedKey: xpub1},
+			{Fingerprint: fp2.String(), DerivationPath: "/86'/0'/0'", ExtendedKey: xpub2},
+		},
+		false,
+	)
+	require.NoError(t, err)
+	require.Equal(t, expected, output.Descriptor)
 }
 
 func TestGenerateDescriptorUseCase_MissingAccountKey(t *testing.T) {

--- a/internal/application/usecase/keygen/interfaces.go
+++ b/internal/application/usecase/keygen/interfaces.go
@@ -71,9 +71,10 @@ type GenerateDescriptorUseCase interface {
 
 // Input/Output DTOs
 type GenerateDescriptorInput struct {
-	AccountType domainAccount.AccountType
-	AddressType domainAddress.AddrType
-	IsChange    bool
+	AccountType  domainAccount.AccountType
+	AddressType  domainAddress.AddrType
+	IsChange     bool
+	RequiredSigs int // Optional for multisig; 0 selects the minimal required-sigs config
 }
 
 type GenerateDescriptorOutput struct {


### PR DESCRIPTION
## Description
Adds application-layer descriptor generation use case covering single-sig and multisig accounts, wiring descriptor service and repository data. Includes interface definitions and unit tests.

## Changes
- add GenerateDescriptorUseCase interface and DTOs
- implement descriptor generation use case with derivation path selection, fingerprinting, and multisig signer assembly
- add unit tests for single-sig, multisig wsh, and taproot script-path descriptors

## Testing
- [x] go test ./internal/application/usecase/keygen/btc
- [ ] make lint-fix
- [ ] make tidy
- [ ] make check-build
- [ ] make gotest

Closes #182
