### PR TITLE
Phase 2 Batch 2: Refactor sign use cases to use persistence port interfaces

### DIFF
--- a/internal/application/usecase/sign/btc/export_fullpubkey.go
+++ b/internal/application/usecase/sign/btc/export_fullpubkey.go
@@ -12,12 +12,12 @@ import (
 	domainAuth "github.com/hiromaily/go-crypto-wallet/internal/domain/auth"
 	domainCoin "github.com/hiromaily/go-crypto-wallet/internal/domain/coin"
 	domainWallet "github.com/hiromaily/go-crypto-wallet/internal/domain/wallet"
-	"github.com/hiromaily/go-crypto-wallet/internal/infrastructure/repository/cold"
+	"github.com/hiromaily/go-crypto-wallet/internal/application/ports/persistence"
 	"github.com/hiromaily/go-crypto-wallet/internal/infrastructure/storage/file/fullpubkey"
 )
 
 type exportFullPubkeyUseCase struct {
-	authKeyRepo    cold.AuthAccountKeyRepositorier
+	authKeyRepo    persistence.AuthAccountKeyRepositorier
 	pubkeyFileRepo portsStorage.AddressFileRepositorier
 	coinTypeCode   domainCoin.CoinTypeCode
 	authType       domainAccount.AuthType
@@ -26,7 +26,7 @@ type exportFullPubkeyUseCase struct {
 
 // NewExportFullPubkeyUseCase creates a new ExportFullPubkeyUseCase for sign wallet
 func NewExportFullPubkeyUseCase(
-	authKeyRepo cold.AuthAccountKeyRepositorier,
+	authKeyRepo persistence.AuthAccountKeyRepositorier,
 	pubkeyFileRepo portsStorage.AddressFileRepositorier,
 	coinTypeCode domainCoin.CoinTypeCode,
 	authType domainAccount.AuthType,

--- a/internal/application/usecase/sign/btc/import_private_key.go
+++ b/internal/application/usecase/sign/btc/import_private_key.go
@@ -12,13 +12,13 @@ import (
 	domainAddress "github.com/hiromaily/go-crypto-wallet/internal/domain/address"
 	domainCoin "github.com/hiromaily/go-crypto-wallet/internal/domain/coin"
 	domainWallet "github.com/hiromaily/go-crypto-wallet/internal/domain/wallet"
-	"github.com/hiromaily/go-crypto-wallet/internal/infrastructure/repository/cold"
+	"github.com/hiromaily/go-crypto-wallet/internal/application/ports/persistence"
 	"github.com/hiromaily/go-crypto-wallet/pkg/logger"
 )
 
 type importPrivateKeyUseCase struct {
 	btc         portsBtc.Bitcoiner
-	authKeyRepo cold.AuthAccountKeyRepositorier
+	authKeyRepo persistence.AuthAccountKeyRepositorier
 	authType    domainAccount.AuthType
 	wtype       domainWallet.WalletType
 }
@@ -26,7 +26,7 @@ type importPrivateKeyUseCase struct {
 // NewImportPrivateKeyUseCase creates a new ImportPrivateKeyUseCase for sign wallet
 func NewImportPrivateKeyUseCase(
 	btc portsBtc.Bitcoiner,
-	authKeyRepo cold.AuthAccountKeyRepositorier,
+	authKeyRepo persistence.AuthAccountKeyRepositorier,
 	authType domainAccount.AuthType,
 	wtype domainWallet.WalletType,
 ) signusecase.ImportPrivateKeyUseCase {

--- a/internal/application/usecase/sign/btc/musig2_nonce.go
+++ b/internal/application/usecase/sign/btc/musig2_nonce.go
@@ -10,20 +10,20 @@ import (
 	signusecase "github.com/hiromaily/go-crypto-wallet/internal/application/usecase/sign"
 	"github.com/hiromaily/go-crypto-wallet/internal/domain/multisig"
 	"github.com/hiromaily/go-crypto-wallet/internal/infrastructure/api/bitcoin/btc"
-	"github.com/hiromaily/go-crypto-wallet/internal/infrastructure/repository/cold"
+	"github.com/hiromaily/go-crypto-wallet/internal/application/ports/persistence"
 )
 
 type generateMuSig2NonceUseCase struct {
 	musig2Service *btc.MuSig2Service
 	nonceRepo     multisig.NonceRepository
-	authKeyRepo   cold.AuthAccountKeyRepositorier
+	authKeyRepo   persistence.AuthAccountKeyRepositorier
 }
 
 // NewGenerateMuSig2NonceUseCase creates a new GenerateMuSig2NonceUseCase for BTC sign wallet.
 func NewGenerateMuSig2NonceUseCase(
 	musig2Service *btc.MuSig2Service,
 	nonceRepo multisig.NonceRepository,
-	authKeyRepo cold.AuthAccountKeyRepositorier,
+	authKeyRepo persistence.AuthAccountKeyRepositorier,
 ) signusecase.GenerateMuSig2NonceUseCase {
 	return &generateMuSig2NonceUseCase{
 		musig2Service: musig2Service,

--- a/internal/application/usecase/sign/btc/musig2_sign.go
+++ b/internal/application/usecase/sign/btc/musig2_sign.go
@@ -10,20 +10,20 @@ import (
 	signusecase "github.com/hiromaily/go-crypto-wallet/internal/application/usecase/sign"
 	"github.com/hiromaily/go-crypto-wallet/internal/domain/multisig"
 	"github.com/hiromaily/go-crypto-wallet/internal/infrastructure/api/bitcoin/btc"
-	"github.com/hiromaily/go-crypto-wallet/internal/infrastructure/repository/cold"
+	"github.com/hiromaily/go-crypto-wallet/internal/application/ports/persistence"
 )
 
 type muSig2SignUseCase struct {
 	musig2Service *btc.MuSig2Service
 	nonceRepo     multisig.NonceRepository
-	authKeyRepo   cold.AuthAccountKeyRepositorier
+	authKeyRepo   persistence.AuthAccountKeyRepositorier
 }
 
 // NewMuSig2SignUseCase creates a new MuSig2SignUseCase for BTC sign wallet.
 func NewMuSig2SignUseCase(
 	musig2Service *btc.MuSig2Service,
 	nonceRepo multisig.NonceRepository,
-	authKeyRepo cold.AuthAccountKeyRepositorier,
+	authKeyRepo persistence.AuthAccountKeyRepositorier,
 ) signusecase.MuSig2SignUseCase {
 	return &muSig2SignUseCase{
 		musig2Service: musig2Service,

--- a/internal/application/usecase/sign/btc/sign_transaction.go
+++ b/internal/application/usecase/sign/btc/sign_transaction.go
@@ -10,14 +10,14 @@ import (
 	domainAccount "github.com/hiromaily/go-crypto-wallet/internal/domain/account"
 	domainTx "github.com/hiromaily/go-crypto-wallet/internal/domain/transaction"
 	domainWallet "github.com/hiromaily/go-crypto-wallet/internal/domain/wallet"
-	"github.com/hiromaily/go-crypto-wallet/internal/infrastructure/repository/cold"
+	"github.com/hiromaily/go-crypto-wallet/internal/application/ports/persistence"
 	"github.com/hiromaily/go-crypto-wallet/pkg/logger"
 )
 
 type signTransactionUseCase struct {
 	btc             portsBtc.Bitcoiner
-	accountKeyRepo  cold.BTCAccountKeyRepositorier
-	authKeyRepo     cold.AuthAccountKeyRepositorier
+	accountKeyRepo  persistence.BTCAccountKeyRepositorier
+	authKeyRepo     persistence.AuthAccountKeyRepositorier
 	txFileRepo      portsStorage.TransactionFileRepositorier
 	multisigAccount *domainAccount.MultisigConfig
 	wtype           domainWallet.WalletType
@@ -27,8 +27,8 @@ type signTransactionUseCase struct {
 // NewSignTransactionUseCase creates a new SignTransactionUseCase for sign wallet
 func NewSignTransactionUseCase(
 	btcAPI portsBtc.Bitcoiner,
-	accountKeyRepo cold.BTCAccountKeyRepositorier,
-	authKeyRepo cold.AuthAccountKeyRepositorier,
+	accountKeyRepo persistence.BTCAccountKeyRepositorier,
+	authKeyRepo persistence.AuthAccountKeyRepositorier,
 	txFileRepo portsStorage.TransactionFileRepositorier,
 	multisigAccount *domainAccount.MultisigConfig,
 	wtype domainWallet.WalletType,

--- a/internal/application/usecase/sign/shared/generate_auth_key.go
+++ b/internal/application/usecase/sign/shared/generate_auth_key.go
@@ -9,19 +9,19 @@ import (
 	domainAccount "github.com/hiromaily/go-crypto-wallet/internal/domain/account"
 	domainCoin "github.com/hiromaily/go-crypto-wallet/internal/domain/coin"
 	domainKey "github.com/hiromaily/go-crypto-wallet/internal/domain/key"
-	"github.com/hiromaily/go-crypto-wallet/internal/infrastructure/repository/cold"
+	"github.com/hiromaily/go-crypto-wallet/internal/application/ports/persistence"
 	"github.com/hiromaily/go-crypto-wallet/pkg/logger"
 )
 
 type generateAuthKeyUseCase struct {
-	repo         cold.HDWalletRepo
+	repo         persistence.HDWalletRepo
 	keygen       portsWallet.Generator
 	coinTypeCode domainCoin.CoinTypeCode
 }
 
 // NewGenerateAuthKeyUseCase creates a new GenerateAuthKeyUseCase for sign wallet
 func NewGenerateAuthKeyUseCase(
-	repo cold.HDWalletRepo,
+	repo persistence.HDWalletRepo,
 	keygen portsWallet.Generator,
 	coinTypeCode domainCoin.CoinTypeCode,
 ) signusecase.GenerateAuthKeyUseCase {

--- a/internal/application/usecase/sign/shared/generate_seed.go
+++ b/internal/application/usecase/sign/shared/generate_seed.go
@@ -6,17 +6,17 @@ import (
 	"fmt"
 
 	signusecase "github.com/hiromaily/go-crypto-wallet/internal/application/usecase/sign"
-	"github.com/hiromaily/go-crypto-wallet/internal/infrastructure/repository/cold"
+	"github.com/hiromaily/go-crypto-wallet/internal/application/ports/persistence"
 	infraKey "github.com/hiromaily/go-crypto-wallet/internal/infrastructure/wallet/key"
 	"github.com/hiromaily/go-crypto-wallet/pkg/logger"
 )
 
 type generateSeedUseCase struct {
-	seedRepo cold.SeedRepositorier
+	seedRepo persistence.SeedRepositorier
 }
 
 // NewGenerateSeedUseCase creates a new GenerateSeedUseCase for sign wallet
-func NewGenerateSeedUseCase(seedRepo cold.SeedRepositorier) signusecase.GenerateSeedUseCase {
+func NewGenerateSeedUseCase(seedRepo persistence.SeedRepositorier) signusecase.GenerateSeedUseCase {
 	return &generateSeedUseCase{
 		seedRepo: seedRepo,
 	}

--- a/internal/application/usecase/sign/shared/store_seed.go
+++ b/internal/application/usecase/sign/shared/store_seed.go
@@ -5,16 +5,16 @@ import (
 	"fmt"
 
 	signusecase "github.com/hiromaily/go-crypto-wallet/internal/application/usecase/sign"
-	"github.com/hiromaily/go-crypto-wallet/internal/infrastructure/repository/cold"
+	"github.com/hiromaily/go-crypto-wallet/internal/application/ports/persistence"
 	infraKey "github.com/hiromaily/go-crypto-wallet/internal/infrastructure/wallet/key"
 )
 
 type storeSeedUseCase struct {
-	seedRepo cold.SeedRepositorier
+	seedRepo persistence.SeedRepositorier
 }
 
 // NewStoreSeedUseCase creates a new StoreSeedUseCase for sign wallet
-func NewStoreSeedUseCase(seedRepo cold.SeedRepositorier) signusecase.StoreSeedUseCase {
+func NewStoreSeedUseCase(seedRepo persistence.SeedRepositorier) signusecase.StoreSeedUseCase {
 	return &storeSeedUseCase{
 		seedRepo: seedRepo,
 	}

--- a/internal/application/usecase/sign/xrp/sign_transaction.go
+++ b/internal/application/usecase/sign/xrp/sign_transaction.go
@@ -14,13 +14,13 @@ import (
 	domainAccount "github.com/hiromaily/go-crypto-wallet/internal/domain/account"
 	domainTx "github.com/hiromaily/go-crypto-wallet/internal/domain/transaction"
 	domainWallet "github.com/hiromaily/go-crypto-wallet/internal/domain/wallet"
-	"github.com/hiromaily/go-crypto-wallet/internal/infrastructure/repository/cold"
+	"github.com/hiromaily/go-crypto-wallet/internal/application/ports/persistence"
 	"github.com/hiromaily/go-crypto-wallet/pkg/logger"
 )
 
 type signTransactionUseCase struct {
 	xrp               portsRipple.Rippler
-	xrpAccountKeyRepo cold.XRPAccountKeyRepositorier
+	xrpAccountKeyRepo persistence.XRPAccountKeyRepositorier
 	txFileRepo        portsStorage.TransactionFileRepositorier
 	wtype             domainWallet.WalletType
 }
@@ -28,7 +28,7 @@ type signTransactionUseCase struct {
 // NewSignTransactionUseCase creates a new SignTransactionUseCase for sign wallet
 func NewSignTransactionUseCase(
 	xrpAPI portsRipple.Rippler,
-	xrpAccountKeyRepo cold.XRPAccountKeyRepositorier,
+	xrpAccountKeyRepo persistence.XRPAccountKeyRepositorier,
 	txFileRepo portsStorage.TransactionFileRepositorier,
 	wtype domainWallet.WalletType,
 ) signusecase.SignTransactionUseCase {


### PR DESCRIPTION
## Summary
This PR continues the Clean Architecture refactoring (issue #270 Phase 2) by updating sign use cases to import from `application/ports/persistence` instead of directly from `infrastructure/repository/cold`.

This batch also includes the `HDWalletRepo` interface migration (from Phase 1) since it was not yet on the main branch when this branch was created.

## Changes

### Phase 1 (included):
- Added `HDWalletRepo` interface to `internal/application/ports/persistence/repository.go`
- Added type alias for `HDWalletRepo` in `internal/infrastructure/repository/cold/interfaces.go`
- Removed interface definition from `internal/infrastructure/repository/cold/hd_wallet_repo.go`

### Phase 2 Batch 2 (Sign Use Cases):
Updated 9 sign use case files to use persistence interfaces:
- **BTC** (5 files): export_fullpubkey, import_private_key, musig2_nonce, musig2_sign, sign_transaction
- **Shared** (3 files): generate_auth_key, generate_seed, store_seed
- **XRP** (1 file): sign_transaction

All files now import `"github.com/hiromaily/go-crypto-wallet/internal/application/ports/persistence"` instead of `"github.com/hiromaily/go-crypto-wallet/internal/infrastructure/repository/cold"`.

## Testing
- ✅ Build passed: `make check-build`
- ✅ All tests passed: `make gotest`

## Architecture Impact
This change follows the **Dependency Inversion Principle** by ensuring the application layer depends on interfaces it defines (in ports), not on concrete infrastructure implementations. This improves:
- **Testability**: Use cases can be tested with mock implementations
- **Maintainability**: Infrastructure changes don't affect application layer
- **Flexibility**: Can swap implementations without changing use cases

## Progress
- [x] Phase 1: Complete port interface migration (HDWalletRepo)
- [x] Phase 2 Batch 1: Keygen use cases (12 files) - PR #272
- [x] Phase 2 Batch 2: Sign use cases (9 files) - This PR
- [ ] Phase 2 Batch 3: Watch use cases (~17 files)
- [ ] Phase 3: Remove backward compatibility aliases
- [ ] Phase 4: Final verification and documentation

Related to #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)