### PR TITLE
Fix: Bitcoin Cash container startup failure (Closes #280)

### DIFF
--- a/compose.bch.yaml
+++ b/compose.bch.yaml
@@ -50,7 +50,7 @@ services:
       timeout: 10s
       retries: 5
       start_period: 30s
-    command: -printtoconsole
+    command: bitcoind -printtoconsole
 
   bch-keygen:
     image: zquestz/bitcoin-cash-node:28.0.1
@@ -77,7 +77,7 @@ services:
       timeout: 10s
       retries: 5
       start_period: 30s
-    command: -maxconnections=0 -printtoconsole
+    command: bitcoind -maxconnections=0 -printtoconsole
 
   bch-sign1:
     image: zquestz/bitcoin-cash-node:28.0.1
@@ -104,7 +104,7 @@ services:
       timeout: 10s
       retries: 5
       start_period: 30s
-    command: -maxconnections=0 -printtoconsole
+    command: bitcoind -maxconnections=0 -printtoconsole
 
   bch-sign2:
     image: zquestz/bitcoin-cash-node:28.0.1
@@ -131,4 +131,4 @@ services:
       timeout: 10s
       retries: 5
       start_period: 30s
-    command: -maxconnections=0 -printtoconsole
+    command: bitcoind -maxconnections=0 -printtoconsole

--- a/scripts/operation/common.sh
+++ b/scripts/operation/common.sh
@@ -195,12 +195,23 @@ bitcoin_create_wallet_if_needed() {
             loadwallet "$wallet_name" >/dev/null 2>&1 || true
     else
         log_info "Creating wallet '$wallet_name' in $container"
-        # Create legacy wallet (descriptors=false) for compatibility with importprivkey command
-        # Parameters: wallet_name, disable_private_keys, blank, passphrase, avoid_reuse, descriptors
-        docker exec "$container" bitcoin-cli -regtest \
-            -rpcuser="${rpc_user}" \
-            -rpcpassword="${rpc_password}" \
-            createwallet "$wallet_name" false false "" false false >/dev/null
+        # Bitcoin Cash Node (BCH) has different createwallet API than Bitcoin Core
+        # BCH: createwallet "wallet_name" (disable_private_keys blank)
+        # BTC: createwallet "wallet_name" (disable_private_keys blank passphrase avoid_reuse descriptors load_on_startup external_signer)
+        if [[ "$container" == bch-* ]]; then
+            # BCH: Use 3-parameter format (wallet_name, disable_private_keys, blank)
+            docker exec "$container" bitcoin-cli -regtest \
+                -rpcuser="${rpc_user}" \
+                -rpcpassword="${rpc_password}" \
+                createwallet "$wallet_name" false false >/dev/null
+        else
+            # BTC: Create legacy wallet (descriptors=false) for compatibility with importprivkey command
+            # Parameters: wallet_name, disable_private_keys, blank, passphrase, avoid_reuse, descriptors
+            docker exec "$container" bitcoin-cli -regtest \
+                -rpcuser="${rpc_user}" \
+                -rpcpassword="${rpc_password}" \
+                createwallet "$wallet_name" false false "" false false >/dev/null
+        fi
     fi
 }
 


### PR DESCRIPTION
## Description
This PR fixes the Bitcoin Cash Node container startup failure and wallet creation issues in the BCH E2E workflow. The fix addresses two separate problems that were preventing `make bch-e2e-test-reset` from completing successfully.

## Problems Fixed

### 1. Container Startup Failure
All BCH containers (bch-watch, bch-keygen, bch-sign1, bch-sign2) were crashing with exit code 2 immediately after starting.

**Root Cause**: The zquestz/bitcoin-cash-node:28.0.1 Docker image uses an entrypoint script that expects the full `bitcoind` command followed by arguments, not just the arguments alone. The previous configuration passed arguments like `-printtoconsole` directly, which caused the entrypoint script to fail with:
```
/entrypoint.sh: line 27: exec: -p: invalid option
```

### 2. Wallet Creation API Mismatch
After containers started successfully, wallet creation failed with an error showing incorrect number of parameters.

**Root Cause**: Bitcoin Cash Node's `createwallet` RPC command supports only 3 parameters (wallet_name, disable_private_keys, blank), while Bitcoin Core supports 6+ parameters (wallet_name, disable_private_keys, blank, passphrase, avoid_reuse, descriptors). The script was using Bitcoin Core's 6-parameter format for all containers.

## Changes

### compose.bch.yaml
Updated all service commands to include `bitcoind` executable:
- `bch-watch`: `-printtoconsole` → `bitcoind -printtoconsole`
- `bch-keygen`: `-maxconnections=0 -printtoconsole` → `bitcoind -maxconnections=0 -printtoconsole`
- `bch-sign1`: `-maxconnections=0 -printtoconsole` → `bitcoind -maxconnections=0 -printtoconsole`
- `bch-sign2`: `-maxconnections=0 -printtoconsole` → `bitcoind -maxconnections=0 -printtoconsole`

### scripts/operation/common.sh
Updated `bitcoin_create_wallet_if_needed()` function to handle both BTC and BCH:
- Added container type detection using `bch-*` prefix pattern
- BCH containers use 3-parameter createwallet format
- BTC containers continue using 6-parameter format for legacy wallet support
- Added inline documentation explaining the API differences

## Testing

### Manual Container Testing
- [x] All BCH containers start successfully without crashing
- [x] All containers pass healthcheck and show as "healthy"
- [x] RPC connections verified working:
  - `docker exec bch-watch bitcoin-cli -regtest -rpcuser=xyz -rpcpassword=xyz getblockchaininfo` ✓
  - `docker exec bch-keygen bitcoin-cli -regtest -rpcuser=xyz -rpcpassword=xyz getnetworkinfo` ✓
- [x] Offline nodes (keygen, sign1, sign2) correctly show 0 connections with `-maxconnections=0`

### Wallet Creation Testing
- [x] BCH wallet creation succeeds with 3-parameter format
- [x] All four BCH wallets created successfully (watch, keygen, sign1, sign2)

### Full E2E Workflow
- [x] `make bch-e2e-test-reset` completes successfully
- [x] Infrastructure setup phase passes
- [x] Wallet setup phase passes
- [x] Key generation phase passes
- [x] Full workflow completes with success message

## Verification
- [x] `make go-lint` passes
- [x] `make tidy` passes
- [x] `make check-build` passes
- [x] No breaking changes to BTC workflow (uses separate code path)

## Impact
This fix enables the BCH E2E workflow to run successfully from start to finish. The changes are backwards compatible and don't affect the BTC workflow, which continues to use its existing 6-parameter createwallet format.

The fix properly handles the differences between:
- Docker image entrypoint behavior (bitcoin/bitcoin vs zquestz/bitcoin-cash-node)
- RPC API compatibility (Bitcoin Core vs Bitcoin Cash Node)

## References
- Bitcoin Cash Node image documentation: https://github.com/zquestz/docker-bitcoin
- Issue describes both container startup and E2E workflow problems

Closes #280