### PR TITLE
ci: add Conventional Commits validation via lefthook (Closes #413 Phase 4)

### DIFF
--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -170,6 +170,8 @@ fix!: remove deprecated API endpoint
 
 ### Scope (Optional)
 
+The following are suggested scopes, but other alphanumeric scopes are also permitted.
+
 | Scope | Description |
 |-------|-------------|
 | `btc` | Bitcoin-related |
@@ -226,6 +228,14 @@ ERROR: Commit message does not follow Conventional Commits format.
 Expected format: <type>(<scope>): <description>
 
 Types: feat, fix, docs, refactor, test, ci, chore, build, perf, style, revert
+
+Examples:
+  feat(btc): add taproot address support
+  fix: resolve database connection timeout
+  docs: update architecture guide
+  refactor(api): reorganize endpoint handlers
+
+Your commit message: <your-invalid-commit-message>
 ```
 
 ## Pull Request Creation

--- a/docs/standards/workflow.md
+++ b/docs/standards/workflow.md
@@ -59,6 +59,8 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org/) f
 
 ### Scopes (Optional)
 
+The following are suggested scopes, but other alphanumeric scopes are also permitted.
+
 | Scope | Description |
 |-------|-------------|
 | `btc` | Bitcoin-related |
@@ -97,6 +99,16 @@ Commit messages are validated by `lefthook` on every commit. If validation fails
 ERROR: Commit message does not follow Conventional Commits format.
 
 Expected format: <type>(<scope>): <description>
+
+Types: feat, fix, docs, refactor, test, ci, chore, build, perf, style, revert
+
+Examples:
+  feat(btc): add taproot address support
+  fix: resolve database connection timeout
+  docs: update architecture guide
+  refactor(api): reorganize endpoint handlers
+
+Your commit message: <your-invalid-commit-message>
 ```
 
 ## Verification Checklist

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -13,16 +13,9 @@ commit-msg:
         merge_pattern="^Merge (branch|pull request|remote-tracking branch)"
         revert_pattern="^Revert \""
 
-        commit_msg=$(cat "$1")
-        first_line=$(echo "$commit_msg" | head -n 1)
+        first_line=$(head -n 1 "$1")
 
-        if echo "$first_line" | grep -qE "$pattern"; then
-          exit 0
-        elif echo "$first_line" | grep -qE "$merge_pattern"; then
-          exit 0
-        elif echo "$first_line" | grep -qE "$revert_pattern"; then
-          exit 0
-        else
+        if ! echo "$first_line" | grep -qE "${pattern}|${merge_pattern}|${revert_pattern}"; then
           echo "ERROR: Commit message does not follow Conventional Commits format."
           echo ""
           echo "Expected format: <type>(<scope>): <description>"


### PR DESCRIPTION
## Summary

Add automated validation for Conventional Commits format using lefthook commit-msg hook.

## Changes

### lefthook.yml
- Add `commit-msg` hook with Conventional Commits validation
- Support types: `feat`, `fix`, `docs`, `refactor`, `test`, `ci`, `chore`, `build`, `perf`, `style`, `revert`
- Allow optional scope: `feat(btc): description`
- Allow breaking changes: `feat!:` or `feat(btc)!:`
- Allow merge commits and revert commits

### docs/standards/workflow.md
- Expanded commit message documentation with:
  - Type descriptions and release impact
  - Scope options (btc, bch, eth, xrp, db, api, cli, pr)
  - Examples of valid commit messages
  - Validation error explanation

## Usage

When committing with invalid format:
```
$ git commit -m "added feature"
ERROR: Commit message does not follow Conventional Commits format.

Expected format: <type>(<scope>): <description>

Types: feat, fix, docs, refactor, test, ci, chore, build, perf, style, revert

Examples:
  feat(btc): add taproot address support
  fix: resolve database connection timeout
```

When committing with valid format:
```
$ git commit -m "feat(btc): add taproot address support"
[branch abc1234] feat(btc): add taproot address support
```

## Test Plan

- [x] Commit with valid Conventional Commits format succeeds
- [x] Documentation updated in docs/standards/workflow.md

Closes #413 (Phase 4)