### PR TITLE
fix: remove unsupported YAML anchors from goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,44 +3,61 @@
 #
 # GoReleaser configuration for go-crypto-wallet
 # https://goreleaser.com/customization/
+#
+# NOTE: GoReleaser does NOT support top-level YAML anchors (e.g., .common: &common).
+# All build configurations must be explicitly defined for each target.
+# See: https://github.com/goreleaser/goreleaser/issues/3902
 version: 2
 
 before:
   hooks:
     - go mod tidy
 
-# YAML anchors for DRY configuration
-.common_build: &common_build
-  env:
-    - CGO_ENABLED=0
-  goos:
-    - linux
-    - darwin
-  goarch:
-    - amd64
-    - arm64
-  ldflags:
-    - -s -w
-    - -X main.appVersion={{.Version}}
-
 builds:
   # Watch wallet (online)
   - id: watch
-    <<: *common_build
     main: ./cmd/watch
     binary: watch
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.appVersion={{.Version}}
 
   # Keygen wallet (offline cold wallet)
   - id: keygen
-    <<: *common_build
     main: ./cmd/keygen
     binary: keygen
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.appVersion={{.Version}}
 
   # Sign wallet - auth1 (offline cold wallet)
   - id: sign-auth1
-    <<: *common_build
     main: ./cmd/sign
     binary: sign-auth1
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
     ldflags:
       - -s -w
       - -X main.appVersion={{.Version}}
@@ -48,9 +65,16 @@ builds:
 
   # Sign wallet - auth2 (offline cold wallet)
   - id: sign-auth2
-    <<: *common_build
     main: ./cmd/sign
     binary: sign-auth2
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
     ldflags:
       - -s -w
       - -X main.appVersion={{.Version}}


### PR DESCRIPTION
## Summary

Fix GoReleaser configuration that was failing due to unsupported YAML anchor syntax.

## Problem

The v6.0.1 release workflow failed with:
```
yaml: unmarshal errors:
  line 13: field .common_build not found in type config.Project
```

GoReleaser does not support top-level YAML anchor definitions (`.common_build: &common_build`).

## Solution

Reverted to explicit build configurations for each target, removing the YAML anchors that were added in PR #416.

## Test Plan

- [ ] After merge, create v6.0.2 tag to verify release workflow succeeds