### PR TITLE
docs: add CONTRIBUTING.md with commit message conventions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ Commit messages are validated by `lefthook` on every commit.
 
 ### Scopes (Optional)
 
-The following are suggested scopes, but other alphanumeric scopes are also permitted.
+The following are suggested scopes, but other alphanumeric scopes (including hyphens and underscores) are also permitted.
 
 | Scope | Description |
 |-------|-------------|
@@ -145,10 +145,10 @@ Your commit message: <your-invalid-commit-message>
 ### PR Title Format
 
 ```
-<type>: <description> (Closes #<issue_number>)
+<type>: <description>
 ```
 
-Example: `feat: add taproot address support (Closes #123)`
+Example: `feat: add taproot address support`
 
 ### PR Description Template
 


### PR DESCRIPTION
## Summary

Add CONTRIBUTING.md to document contribution guidelines, with focus on commit message conventions.

## Changes

- Document Conventional Commits format and validation
- Include all commit types (feat, fix, docs, refactor, test, ci, chore, build, perf, style, revert)
- Document optional scopes (btc, bch, eth, xrp, db, api, cli, pr)
- Add breaking change syntax (`!` after type/scope)
- Include validation error message example
- Add branch naming conventions
- Add PR guidelines and checklist
- Reference existing documentation

## Test Plan

- [x] Markdown formatting is correct
- [x] Links to existing documentation are valid

Relates to #413