### PR TITLE
refactor(config): nest mysql/sqlite under database with coin-specific paths

### DIFF
--- a/config/wallet/bch/keygen.yaml
+++ b/config/wallet/bch/keygen.yaml
@@ -35,17 +35,15 @@ tracer:
 # Database configuration - choose between mysql or sqlite
 database:
   type: "mysql" # mysql, sqlite
-mysql:
-  host: "127.0.0.1:3306"
-  dbname: "keygen"
-  user: "hiromaily"
-  pass: "hiromaily"
-  debug: true
-# SQLite configuration (used when database.type = "sqlite")
-# Uncomment and set database.type to "sqlite" to use SQLite instead of MySQL
-# sqlite:
-#   path: "./data/db/keygen.db"
-#   debug: true
+  mysql:
+    host: "127.0.0.1:3306"
+    dbname: "keygen"
+    user: "hiromaily"
+    pass: "hiromaily"
+    debug: true
+  sqlite:
+    path: "./data/sqlite/bch/keygen.db"
+    debug: true
 file_path:
   tx: "./data/tx/bch/"
   address: "./data/address/bch/"

--- a/config/wallet/bch/sign.yaml
+++ b/config/wallet/bch/sign.yaml
@@ -36,17 +36,15 @@ tracer:
 # Database configuration - choose between mysql or sqlite
 database:
   type: "mysql" # mysql, sqlite
-mysql:
-  host: "127.0.0.1:3306"
-  dbname: "sign"
-  user: "hiromaily"
-  pass: "hiromaily"
-  debug: true
-# SQLite configuration (used when database.type = "sqlite")
-# Uncomment and set database.type to "sqlite" to use SQLite instead of MySQL
-# sqlite:
-#   path: "./data/db/sign.db"
-#   debug: true
+  mysql:
+    host: "127.0.0.1:3306"
+    dbname: "sign"
+    user: "hiromaily"
+    pass: "hiromaily"
+    debug: true
+  sqlite:
+    path: "./data/sqlite/bch/sign.db"
+    debug: true
 file_path:
   tx: "./data/tx/bch/"
   address: "./data/address/bch/"

--- a/config/wallet/bch/sign1.yaml
+++ b/config/wallet/bch/sign1.yaml
@@ -36,17 +36,15 @@ tracer:
 # Database configuration - choose between mysql or sqlite
 database:
   type: "mysql" # mysql, sqlite
-mysql:
-  host: "127.0.0.1:3306"
-  dbname: "sign"
-  user: "hiromaily"
-  pass: "hiromaily"
-  debug: true
-# SQLite configuration (used when database.type = "sqlite")
-# Uncomment and set database.type to "sqlite" to use SQLite instead of MySQL
-# sqlite:
-#   path: "./data/db/sign1.db"
-#   debug: true
+  mysql:
+    host: "127.0.0.1:3306"
+    dbname: "sign"
+    user: "hiromaily"
+    pass: "hiromaily"
+    debug: true
+  sqlite:
+    path: "./data/sqlite/bch/sign1.db"
+    debug: true
 file_path:
   tx: "./data/tx/bch/"
   address: "./data/address/bch/"

--- a/config/wallet/bch/sign2.yaml
+++ b/config/wallet/bch/sign2.yaml
@@ -36,17 +36,15 @@ tracer:
 # Database configuration - choose between mysql or sqlite
 database:
   type: "mysql" # mysql, sqlite
-mysql:
-  host: "127.0.0.1:3306"
-  dbname: "sign2"
-  user: "hiromaily"
-  pass: "hiromaily"
-  debug: true
-# SQLite configuration (used when database.type = "sqlite")
-# Uncomment and set database.type to "sqlite" to use SQLite instead of MySQL
-# sqlite:
-#   path: "./data/db/sign2.db"
-#   debug: true
+  mysql:
+    host: "127.0.0.1:3306"
+    dbname: "sign2"
+    user: "hiromaily"
+    pass: "hiromaily"
+    debug: true
+  sqlite:
+    path: "./data/sqlite/bch/sign2.db"
+    debug: true
 file_path:
   tx: "./data/tx/bch/"
   address: "./data/address/bch/"

--- a/config/wallet/bch/watch.yaml
+++ b/config/wallet/bch/watch.yaml
@@ -45,17 +45,15 @@ tracer:
 # Database configuration - choose between mysql or sqlite
 database:
   type: "mysql" # mysql, sqlite
-mysql:
-  host: "127.0.0.1:3306"
-  dbname: "watch"
-  user: "hiromaily"
-  pass: "hiromaily"
-  debug: true
-# SQLite configuration (used when database.type = "sqlite")
-# Uncomment and set database.type to "sqlite" to use SQLite instead of MySQL
-# sqlite:
-#   path: "./data/db/watch.db"
-#   debug: true
+  mysql:
+    host: "127.0.0.1:3306"
+    dbname: "watch"
+    user: "hiromaily"
+    pass: "hiromaily"
+    debug: true
+  sqlite:
+    path: "./data/sqlite/bch/watch.db"
+    debug: true
 file_path:
   tx: "./data/tx/bch/"
   address: "./data/address/bch/"

--- a/config/wallet/btc/keygen.yaml
+++ b/config/wallet/btc/keygen.yaml
@@ -41,22 +41,19 @@ tracer:
 # Database configuration - choose between mysql or sqlite
 database:
   type: "mysql" # mysql, sqlite
-mysql:
-  host: "127.0.0.1:3306"
-  dbname: "keygen"
-  user: "hiromaily"
-  pass: "hiromaily"
-  debug: true
-# SQLite configuration (used when database.type = "sqlite")
-# Uncomment and set database.type to "sqlite" to use SQLite instead of MySQL
-# sqlite:
-#   path: "./data/db/keygen.db"
-#   debug: true
+  mysql:
+    host: "127.0.0.1:3306"
+    dbname: "keygen"
+    user: "hiromaily"
+    pass: "hiromaily"
+    debug: true
+  sqlite:
+    path: "./data/sqlite/btc/keygen.db"
+    debug: true
 file_path:
   tx: "./data/tx/btc/"
   address: "./data/address/btc/"
   full_pubkey: "./data/fullpubkey/btc/"
-
 # default seed of key used when dev mode
 # key:
 #   seed: "Ve5Kkaba4SQGavc/pWXazZuYD4mE53+qV9tLeRTS5t4="

--- a/config/wallet/btc/keygen_bip86_test.yaml
+++ b/config/wallet/btc/keygen_bip86_test.yaml
@@ -40,12 +40,18 @@ logger:
 # only available for watch only wallet, but definition is required as none
 tracer:
   type: "none" # none, jaeger, datadog
-mysql:
-  host: "127.0.0.1:3306"
-  dbname: "keygen_bip86_test"
-  user: "hiromaily"
-  pass: "hiromaily"
-  debug: true
+# Database configuration - choose between mysql or sqlite
+database:
+  type: "mysql" # mysql, sqlite
+  mysql:
+    host: "127.0.0.1:3306"
+    dbname: "keygen_bip86_test"
+    user: "hiromaily"
+    pass: "hiromaily"
+    debug: true
+  sqlite:
+    path: "./data/sqlite/btc/keygen_bip86_test.db"
+    debug: true
 file_path:
   tx: "./data/tx/btc/bip86_test/"
   address: "./data/address/btc/bip86_test/"

--- a/config/wallet/btc/sign.yaml
+++ b/config/wallet/btc/sign.yaml
@@ -41,17 +41,15 @@ tracer:
 # Database configuration - choose between mysql or sqlite
 database:
   type: "mysql" # mysql, sqlite
-mysql:
-  host: "127.0.0.1:3306"
-  dbname: "sign"
-  user: "hiromaily"
-  pass: "hiromaily"
-  debug: true
-# SQLite configuration (used when database.type = "sqlite")
-# Uncomment and set database.type to "sqlite" to use SQLite instead of MySQL
-# sqlite:
-#   path: "./data/db/sign.db"
-#   debug: true
+  mysql:
+    host: "127.0.0.1:3306"
+    dbname: "sign"
+    user: "hiromaily"
+    pass: "hiromaily"
+    debug: true
+  sqlite:
+    path: "./data/sqlite/btc/sign.db"
+    debug: true
 file_path:
   tx: "./data/tx/btc/"
   address: "./data/address/btc/"

--- a/config/wallet/btc/sign1.yaml
+++ b/config/wallet/btc/sign1.yaml
@@ -41,17 +41,15 @@ tracer:
 # Database configuration - choose between mysql or sqlite
 database:
   type: "mysql" # mysql, sqlite
-mysql:
-  host: "127.0.0.1:3306"
-  dbname: "sign"
-  user: "hiromaily"
-  pass: "hiromaily"
-  debug: true
-# SQLite configuration (used when database.type = "sqlite")
-# Uncomment and set database.type to "sqlite" to use SQLite instead of MySQL
-# sqlite:
-#   path: "./data/db/sign1.db"
-#   debug: true
+  mysql:
+    host: "127.0.0.1:3306"
+    dbname: "sign"
+    user: "hiromaily"
+    pass: "hiromaily"
+    debug: true
+  sqlite:
+    path: "./data/sqlite/btc/sign1.db"
+    debug: true
 file_path:
   tx: "./data/tx/btc/"
   address: "./data/address/btc/"

--- a/config/wallet/btc/sign2.yaml
+++ b/config/wallet/btc/sign2.yaml
@@ -41,17 +41,15 @@ tracer:
 # Database configuration - choose between mysql or sqlite
 database:
   type: "mysql" # mysql, sqlite
-mysql:
-  host: "127.0.0.1:3306"
-  dbname: "sign2"
-  user: "hiromaily"
-  pass: "hiromaily"
-  debug: true
-# SQLite configuration (used when database.type = "sqlite")
-# Uncomment and set database.type to "sqlite" to use SQLite instead of MySQL
-# sqlite:
-#   path: "./data/db/sign2.db"
-#   debug: true
+  mysql:
+    host: "127.0.0.1:3306"
+    dbname: "sign2"
+    user: "hiromaily"
+    pass: "hiromaily"
+    debug: true
+  sqlite:
+    path: "./data/sqlite/btc/sign2.db"
+    debug: true
 file_path:
   tx: "./data/tx/btc/"
   address: "./data/address/btc/"

--- a/config/wallet/btc/watch.yaml
+++ b/config/wallet/btc/watch.yaml
@@ -50,17 +50,15 @@ tracer:
 # Database configuration - choose between mysql or sqlite
 database:
   type: "mysql" # mysql, sqlite
-mysql:
-  host: "127.0.0.1:3306"
-  dbname: "watch"
-  user: "hiromaily"
-  pass: "hiromaily"
-  debug: true
-# SQLite configuration (used when database.type = "sqlite")
-# Uncomment and set database.type to "sqlite" to use SQLite instead of MySQL
-# sqlite:
-#   path: "./data/db/watch.db"
-#   debug: true
+  mysql:
+    host: "127.0.0.1:3306"
+    dbname: "watch"
+    user: "hiromaily"
+    pass: "hiromaily"
+    debug: true
+  sqlite:
+    path: "./data/sqlite/btc/watch.db"
+    debug: true
 file_path:
   tx: "./data/tx/btc/"
   address: "./data/address/btc/"

--- a/config/wallet/eth/keygen.yaml
+++ b/config/wallet/eth/keygen.yaml
@@ -32,17 +32,15 @@ tracer:
 # Database configuration - choose between mysql or sqlite
 database:
   type: "mysql" # mysql, sqlite
-mysql:
-  host: "127.0.0.1:3306"
-  dbname: "keygen"
-  user: "hiromaily"
-  pass: "hiromaily"
-  debug: true
-# SQLite configuration (used when database.type = "sqlite")
-# Uncomment and set database.type to "sqlite" to use SQLite instead of MySQL
-# sqlite:
-#   path: "./data/db/keygen.db"
-#   debug: true
+  mysql:
+    host: "127.0.0.1:3306"
+    dbname: "keygen"
+    user: "hiromaily"
+    pass: "hiromaily"
+    debug: true
+  sqlite:
+    path: "./data/sqlite/eth/keygen.db"
+    debug: true
 file_path:
   tx: "./data/tx/eth/"
   address: "./data/address/eth/"

--- a/config/wallet/eth/sign.yaml
+++ b/config/wallet/eth/sign.yaml
@@ -29,17 +29,15 @@ tracer:
 # Database configuration - choose between mysql or sqlite
 database:
   type: "mysql" # mysql, sqlite
-mysql:
-  host: "127.0.0.1:3306"
-  dbname: "sign"
-  user: "hiromaily"
-  pass: "hiromaily"
-  debug: true
-# SQLite configuration (used when database.type = "sqlite")
-# Uncomment and set database.type to "sqlite" to use SQLite instead of MySQL
-# sqlite:
-#   path: "./data/db/sign.db"
-#   debug: true
+  mysql:
+    host: "127.0.0.1:3306"
+    dbname: "sign"
+    user: "hiromaily"
+    pass: "hiromaily"
+    debug: true
+  sqlite:
+    path: "./data/sqlite/eth/sign.db"
+    debug: true
 file_path:
   tx: "./data/tx/eth/"
   address: "./data/address/eth/"

--- a/config/wallet/eth/watch.yaml
+++ b/config/wallet/eth/watch.yaml
@@ -43,17 +43,15 @@ tracer:
 # Database configuration - choose between mysql or sqlite
 database:
   type: "mysql" # mysql, sqlite
-mysql:
-  host: "127.0.0.1:3306"
-  dbname: "watch"
-  user: "hiromaily"
-  pass: "hiromaily"
-  debug: true
-# SQLite configuration (used when database.type = "sqlite")
-# Uncomment and set database.type to "sqlite" to use SQLite instead of MySQL
-# sqlite:
-#   path: "./data/db/watch.db"
-#   debug: true
+  mysql:
+    host: "127.0.0.1:3306"
+    dbname: "watch"
+    user: "hiromaily"
+    pass: "hiromaily"
+    debug: true
+  sqlite:
+    path: "./data/sqlite/eth/watch.db"
+    debug: true
 file_path:
   tx: "./data/tx/eth/"
   address: "./data/address/eth/"

--- a/config/wallet/xrp/keygen.yaml
+++ b/config/wallet/xrp/keygen.yaml
@@ -34,18 +34,16 @@ tracer:
 # Database configuration - choose between mysql or sqlite
 database:
   type: "mysql" # mysql, sqlite
-mysql:
-  #host = "192.168.10.101:3308"
-  host: "127.0.0.1:3306"
-  dbname: "keygen"
-  user: "hiromaily"
-  pass: "hiromaily"
-  debug: false
-# SQLite configuration (used when database.type = "sqlite")
-# Uncomment and set database.type to "sqlite" to use SQLite instead of MySQL
-# sqlite:
-#   path: "./data/db/keygen.db"
-#   debug: true
+  mysql:
+    # host: "192.168.10.101:3308"
+    host: "127.0.0.1:3306"
+    dbname: "keygen"
+    user: "hiromaily"
+    pass: "hiromaily"
+    debug: false
+  sqlite:
+    path: "./data/sqlite/xrp/keygen.db"
+    debug: true
 file_path:
   tx: "./data/tx/xrp/"
   address: "./data/address/xrp/"

--- a/config/wallet/xrp/watch.yaml
+++ b/config/wallet/xrp/watch.yaml
@@ -39,18 +39,16 @@ tracer:
 # Database configuration - choose between mysql or sqlite
 database:
   type: "mysql" # mysql, sqlite
-mysql:
-  # host = "192.168.10.101:3307"
-  host: "127.0.0.1:3306"
-  dbname: "watch"
-  user: "hiromaily"
-  pass: "hiromaily"
-  debug: false
-# SQLite configuration (used when database.type = "sqlite")
-# Uncomment and set database.type to "sqlite" to use SQLite instead of MySQL
-# sqlite:
-#   path: "./data/db/watch.db"
-#   debug: true
+  mysql:
+    # host: "192.168.10.101:3307"
+    host: "127.0.0.1:3306"
+    dbname: "watch"
+    user: "hiromaily"
+    pass: "hiromaily"
+    debug: false
+  sqlite:
+    path: "./data/sqlite/xrp/watch.db"
+    debug: true
 file_path:
   tx: "./data/tx/xrp/"
   address: "./data/address/xrp/"

--- a/internal/infrastructure/repository/cold/mysql/nonce_repository_sqlc_test.go
+++ b/internal/infrastructure/repository/cold/mysql/nonce_repository_sqlc_test.go
@@ -29,7 +29,7 @@ func getTestDB(t *testing.T) *sql.DB {
 		log.Fatalf("fail to create config: %v", err)
 	}
 
-	dbConn, err := mysql.NewMySQL(&conf.MySQL)
+	dbConn, err := mysql.NewMySQL(&conf.Database.MySQL)
 	if err != nil {
 		log.Fatalf("fail to create db: %v", err)
 	}

--- a/internal/infrastructure/repository/watch/mysql/eth_detail_tx_sqlc_test.go
+++ b/internal/infrastructure/repository/watch/mysql/eth_detail_tx_sqlc_test.go
@@ -32,7 +32,7 @@ func TestETHDetailTXSqlc(t *testing.T) {
 		log.Fatalf("fail to create config: %v", err)
 	}
 	_ = logger.NewSlogLogger(conf.Logger.Format, conf.Logger.Level, conf.Logger.Service, "")
-	db, err := pkgmysql.NewMySQL(&conf.MySQL)
+	db, err := pkgmysql.NewMySQL(&conf.Database.MySQL)
 	if err != nil {
 		log.Fatalf("fail to create db: %v", err)
 	}

--- a/internal/infrastructure/repository/watch/mysql/tx_sqlc_test.go
+++ b/internal/infrastructure/repository/watch/mysql/tx_sqlc_test.go
@@ -30,7 +30,7 @@ func TestTxSqlc(t *testing.T) {
 		log.Fatalf("fail to create config: %v", err)
 	}
 	_ = logger.NewSlogLogger(conf.Logger.Format, conf.Logger.Level, conf.Logger.Service, "")
-	db, err := pkgmysql.NewMySQL(&conf.MySQL)
+	db, err := pkgmysql.NewMySQL(&conf.Database.MySQL)
 	if err != nil {
 		log.Fatalf("fail to create db: %v", err)
 	}

--- a/internal/infrastructure/repository/watch/mysql/xrp_detail_tx_sqlc_test.go
+++ b/internal/infrastructure/repository/watch/mysql/xrp_detail_tx_sqlc_test.go
@@ -32,7 +32,7 @@ func TestXrpDetailTxSqlc(t *testing.T) {
 		log.Fatalf("fail to create config: %v", err)
 	}
 	_ = logger.NewSlogLogger(conf.Logger.Format, conf.Logger.Level, conf.Logger.Service, "")
-	db, err := pkgmysql.NewMySQL(&conf.MySQL)
+	db, err := pkgmysql.NewMySQL(&conf.Database.MySQL)
 	if err != nil {
 		log.Fatalf("fail to create db: %v", err)
 	}

--- a/internal/infrastructure/repository/watch/testutil/testutil.go
+++ b/internal/infrastructure/repository/watch/testutil/testutil.go
@@ -37,7 +37,7 @@ func NewBTCTxRepositorySqlc() repowatch.BTCTxRepositorier {
 		log.Fatalf("fail to create config: %v", err)
 	}
 
-	db, err := mysql.NewMySQL(&conf.MySQL)
+	db, err := mysql.NewMySQL(&conf.Database.MySQL)
 	if err != nil {
 		log.Fatalf("fail to create db: %v", err)
 	}
@@ -59,7 +59,7 @@ func NewTxRepositorySqlc() repowatch.TxRepositorier {
 		log.Fatalf("fail to create config: %v", err)
 	}
 
-	db, err := mysql.NewMySQL(&conf.MySQL)
+	db, err := mysql.NewMySQL(&conf.Database.MySQL)
 	if err != nil {
 		log.Fatalf("fail to create db: %v", err)
 	}
@@ -81,7 +81,7 @@ func NewAddressRepositorySqlc() repowatch.AddressRepositorier {
 		log.Fatalf("fail to create config: %v", err)
 	}
 
-	db, err := mysql.NewMySQL(&conf.MySQL)
+	db, err := mysql.NewMySQL(&conf.Database.MySQL)
 	if err != nil {
 		log.Fatalf("fail to create db: %v", err)
 	}
@@ -103,7 +103,7 @@ func NewPaymentRequestRepositorySqlc() repowatch.PaymentRequestRepositorier {
 		log.Fatalf("fail to create config: %v", err)
 	}
 
-	db, err := mysql.NewMySQL(&conf.MySQL)
+	db, err := mysql.NewMySQL(&conf.Database.MySQL)
 	if err != nil {
 		log.Fatalf("fail to create db: %v", err)
 	}
@@ -125,7 +125,7 @@ func NewBTCTxInputRepositorySqlc() repowatch.TxInputRepositorier {
 		log.Fatalf("fail to create config: %v", err)
 	}
 
-	db, err := mysql.NewMySQL(&conf.MySQL)
+	db, err := mysql.NewMySQL(&conf.Database.MySQL)
 	if err != nil {
 		log.Fatalf("fail to create db: %v", err)
 	}
@@ -147,7 +147,7 @@ func NewBTCTxOutputRepositorySqlc() repowatch.TxOutputRepositorier {
 		log.Fatalf("fail to create config: %v", err)
 	}
 
-	db, err := mysql.NewMySQL(&conf.MySQL)
+	db, err := mysql.NewMySQL(&conf.Database.MySQL)
 	if err != nil {
 		log.Fatalf("fail to create db: %v", err)
 	}
@@ -169,7 +169,7 @@ func NewETHDetailTXRepositorySqlc() repowatch.ETHDetailTXRepositorier {
 		log.Fatalf("fail to create config: %v", err)
 	}
 
-	db, err := mysql.NewMySQL(&conf.MySQL)
+	db, err := mysql.NewMySQL(&conf.Database.MySQL)
 	if err != nil {
 		log.Fatalf("fail to create db: %v", err)
 	}
@@ -191,7 +191,7 @@ func NewXrpDetailTxRepositorySqlc() repowatch.XRPDetailTXRepositorier {
 		log.Fatalf("fail to create config: %v", err)
 	}
 
-	db, err := mysql.NewMySQL(&conf.MySQL)
+	db, err := mysql.NewMySQL(&conf.Database.MySQL)
 	if err != nil {
 		log.Fatalf("fail to create db: %v", err)
 	}

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -231,11 +231,16 @@ bitcoin:
   http_post_mode: true
   disable_tls: true
   network_type: "regtest"
-mysql:
-  host: "localhost:3306"
-  dbname: "testdb"
-  user: "dbuser"
-  pass: "dbpass"
+database:
+  type: "mysql"
+  mysql:
+    host: "localhost:3306"
+    dbname: "testdb"
+    user: "dbuser"
+    pass: "dbpass"
+  sqlite:
+    path: "./data/sqlite/btc/test.db"
+    debug: false
 logger:
   service: "test-service"
   format: "json"
@@ -264,18 +269,18 @@ file_path:
 			"Other nested values should remain unchanged")
 	})
 
-	t.Run("Override nested mysql.host with WALLET_MYSQL_HOST", func(t *testing.T) {
-		// Set env var for nested key: mysql.host -> WALLET_MYSQL_HOST
-		t.Setenv("WALLET_MYSQL_HOST", "mysql-server:3307")
+	t.Run("Override nested database.mysql.host with WALLET_DATABASE_MYSQL_HOST", func(t *testing.T) {
+		// Set env var for nested key: database.mysql.host -> WALLET_DATABASE_MYSQL_HOST
+		t.Setenv("WALLET_DATABASE_MYSQL_HOST", "mysql-server:3307")
 
 		var conf WalletRoot
 		err := loadConfig(yamlPath, &conf)
 
 		require.NoError(t, err, "loadConfig() should not return error")
-		assert.Equal(t, "mysql-server:3307", conf.MySQL.Host,
-			"Nested key mysql.host should be overridden by WALLET_MYSQL_HOST")
+		assert.Equal(t, "mysql-server:3307", conf.Database.MySQL.Host,
+			"Nested key database.mysql.host should be overridden by WALLET_DATABASE_MYSQL_HOST")
 		// Verify other nested values are not affected
-		assert.Equal(t, "testdb", conf.MySQL.DB,
+		assert.Equal(t, "testdb", conf.Database.MySQL.DB,
 			"Other nested values should remain unchanged")
 	})
 

--- a/pkg/config/wallet.go
+++ b/pkg/config/wallet.go
@@ -25,8 +25,6 @@ type WalletRoot struct {
 	Logger       Logger                  `toml:"logger" yaml:"logger" mapstructure:"logger"`
 	Tracer       Tracer                  `toml:"tracer" yaml:"tracer" mapstructure:"tracer"`
 	Database     Database                `toml:"database" yaml:"database" mapstructure:"database"`
-	MySQL        MySQL                   `toml:"mysql" yaml:"mysql" mapstructure:"mysql"`
-	SQLite       SQLite                  `toml:"sqlite" yaml:"sqlite" mapstructure:"sqlite"`
 	FilePath     FilePath                `toml:"file_path" yaml:"file_path" mapstructure:"file_path"`
 }
 
@@ -132,7 +130,9 @@ type TracerDetail struct {
 
 // Database config for database type selection
 type Database struct {
-	Type string `toml:"type" yaml:"type" mapstructure:"type" validate:"required,oneof=mysql sqlite"`
+	Type   string `toml:"type" yaml:"type" mapstructure:"type" validate:"required,oneof=mysql sqlite"`
+	MySQL  MySQL  `toml:"mysql" yaml:"mysql" mapstructure:"mysql"`
+	SQLite SQLite `toml:"sqlite" yaml:"sqlite" mapstructure:"sqlite"`
 }
 
 // MySQL info
@@ -213,7 +213,7 @@ func (c *WalletRoot) validate(wtype domainWallet.WalletType, coinTypeCode domain
 
 	switch coinTypeCode {
 	case domainCoin.BTC, domainCoin.BCH:
-		if err := validate.StructExcept(c, "Ethereum", "Ripple", "MySQL", "SQLite"); err != nil {
+		if err := validate.StructExcept(c, "Ethereum", "Ripple"); err != nil {
 			return err
 		}
 		switch wtype {
@@ -226,11 +226,11 @@ func (c *WalletRoot) validate(wtype domainWallet.WalletType, coinTypeCode domain
 		default:
 		}
 	case domainCoin.ETH, domainCoin.ERC20:
-		if err := validate.StructExcept(c, "AddressType", "Bitcoin", "Ripple", "MySQL", "SQLite"); err != nil {
+		if err := validate.StructExcept(c, "AddressType", "Bitcoin", "Ripple"); err != nil {
 			return err
 		}
 	case domainCoin.XRP:
-		if err := validate.StructExcept(c, "AddressType", "Bitcoin", "Ethereum", "MySQL", "SQLite"); err != nil {
+		if err := validate.StructExcept(c, "AddressType", "Bitcoin", "Ethereum"); err != nil {
 			return err
 		}
 	case domainCoin.LTC, domainCoin.HYT:
@@ -251,22 +251,22 @@ func (c *WalletRoot) validateDatabase() error {
 	switch c.Database.Type {
 	case "mysql":
 		// Validate MySQL configuration
-		if c.MySQL.Host == "" {
-			return errors.New("mysql.host is required when database.type is mysql")
+		if c.Database.MySQL.Host == "" {
+			return errors.New("database.mysql.host is required when database.type is mysql")
 		}
-		if c.MySQL.DB == "" {
-			return errors.New("mysql.dbname is required when database.type is mysql")
+		if c.Database.MySQL.DB == "" {
+			return errors.New("database.mysql.dbname is required when database.type is mysql")
 		}
-		if c.MySQL.User == "" {
-			return errors.New("mysql.user is required when database.type is mysql")
+		if c.Database.MySQL.User == "" {
+			return errors.New("database.mysql.user is required when database.type is mysql")
 		}
-		if c.MySQL.Pass == "" {
-			return errors.New("mysql.pass is required when database.type is mysql")
+		if c.Database.MySQL.Pass == "" {
+			return errors.New("database.mysql.pass is required when database.type is mysql")
 		}
 	case "sqlite":
 		// Validate SQLite configuration
-		if c.SQLite.Path == "" {
-			return errors.New("sqlite.path is required when database.type is sqlite")
+		if c.Database.SQLite.Path == "" {
+			return errors.New("database.sqlite.path is required when database.type is sqlite")
 		}
 	default:
 		return fmt.Errorf("unsupported database type: %s (must be mysql or sqlite)", c.Database.Type)

--- a/pkg/config/wallet_test.go
+++ b/pkg/config/wallet_test.go
@@ -159,7 +159,7 @@ func validateRippleConfig(t *testing.T, conf *WalletRoot) {
 func validateCommonConfig(t *testing.T, conf *WalletRoot) {
 	t.Helper()
 	assert.NotEmpty(t, conf.Logger.Service, "Logger.Service should not be empty")
-	assert.NotEmpty(t, conf.MySQL.Host, "MySQL.Host should not be empty")
+	assert.NotEmpty(t, conf.Database.MySQL.Host, "Database.MySQL.Host should not be empty")
 }
 
 // TestNewWallet_YAML tests the NewWallet function with YAML configuration files.
@@ -212,13 +212,15 @@ tracer:
 
 database:
   type: mysql
-
-mysql:
-  host: localhost:3306
-  dbname: test_db
-  user: root
-  pass: root
-  debug: false
+  mysql:
+    host: localhost:3306
+    dbname: test_db
+    user: root
+    pass: root
+    debug: false
+  sqlite:
+    path: ./data/sqlite/btc/test.db
+    debug: false
 
 file_path:
   tx: /tmp/tx
@@ -237,7 +239,7 @@ file_path:
 	// Verify that viper properly loaded the YAML file
 	assert.NotEmpty(t, conf.Bitcoin.Host, "Bitcoin.Host should not be empty")
 	assert.NotEmpty(t, conf.Logger.Service, "Logger.Service should not be empty")
-	assert.NotEmpty(t, conf.MySQL.Host, "MySQL.Host should not be empty")
+	assert.NotEmpty(t, conf.Database.MySQL.Host, "Database.MySQL.Host should not be empty")
 
 	// Verify nested structures are loaded correctly
 	assert.NotZero(t, conf.Bitcoin.Block.ConfirmationNum, "Bitcoin.Block.ConfirmationNum should not be zero")

--- a/pkg/db/mysql/testutil/connection.go
+++ b/pkg/db/mysql/testutil/connection.go
@@ -27,7 +27,7 @@ func GetDB() *sql.DB {
 		log.Fatalf("fail to create config: %v", err)
 	}
 
-	dbConn, err = mysql.NewMySQL(&conf.MySQL)
+	dbConn, err = mysql.NewMySQL(&conf.Database.MySQL)
 	if err != nil {
 		log.Fatalf("fail to create db: %v", err)
 	}

--- a/pkg/di/container.go
+++ b/pkg/di/container.go
@@ -91,7 +91,7 @@ func (c *pkgContainer) NewDatabaseClient() *sql.DB {
 // NewMySQLClient creates a new MySQL client
 func (c *pkgContainer) NewMySQLClient() *sql.DB {
 	if c.mysqlClient == nil {
-		dbConn, err := mysql.NewMySQL(&c.config.MySQL)
+		dbConn, err := mysql.NewMySQL(&c.config.Database.MySQL)
 		if err != nil {
 			panic(err)
 		}
@@ -103,7 +103,7 @@ func (c *pkgContainer) NewMySQLClient() *sql.DB {
 // NewSQLiteClient creates a new SQLite client
 func (c *pkgContainer) NewSQLiteClient() *sql.DB {
 	if c.sqliteClient == nil {
-		dbConn, err := sqlite.NewSQLite(&c.config.SQLite)
+		dbConn, err := sqlite.NewSQLite(&c.config.Database.SQLite)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
## Summary

- Move MySQL and SQLite config to be nested under `database` section
- SQLite paths include coin type directory for parallel execution:
  - `./data/sqlite/btc/*.db`
  - `./data/sqlite/bch/*.db`
  - `./data/sqlite/eth/*.db`
  - `./data/sqlite/xrp/*.db`
- Update `pkg/config/wallet.go` Database struct to include MySQL/SQLite
- Update `pkg/di/container.go` to use new config path

## Breaking Changes

- Config structure: `mysql:` and `sqlite:` now nested under `database:`
- Environment variable: `WALLET_MYSQL_HOST` → `WALLET_DATABASE_MYSQL_HOST`

## Test Plan

- [x] `make check-build` passes
- [x] `make go-lint` passes