### PR TITLE
fix(btc): add --account-config flag for multisig descriptor export in P2 E2E

### DIFF
--- a/scripts/operation/btc/btc_common.sh
+++ b/scripts/operation/btc/btc_common.sh
@@ -743,8 +743,7 @@ btc_wait_for_balance() {
 		local trusted_balance
 		trusted_balance=$(
 			set +x 2>/dev/null
-			balance_json=$(btc_cli "btc-watch" -rpcwallet=watch getbalances 2>/dev/null || echo '{}')
-			echo "$balance_json" | jq -r '.mine.trusted // 0' 2>/dev/null || echo "0"
+			btc_cli "btc-watch" -rpcwallet=watch getbalances 2>/dev/null | jq -r '.mine.trusted // 0' 2>/dev/null || echo "0"
 		)
 
 		# Check if we have any trusted (mature) balance

--- a/scripts/operation/btc/e2e/e2e-p10-p2tr-musig2.sh
+++ b/scripts/operation/btc/e2e/e2e-p10-p2tr-musig2.sh
@@ -121,20 +121,19 @@ musig2_setup_phase() {
 	log_warn "MuSig2 descriptor export is currently a placeholder"
 
 	log_substep "Exporting descriptors from keygen wallet"
-	file_descriptor_deposit=$(btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --account-config "${BTC_ACCOUNT_CONF}" --coin "${BTC_COIN}" descriptor export --account deposit --output data/descriptor/btc/deposit_descriptors.json --format bitcoin-core --include-change)
-	file_descriptor_payment=$(btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --account-config "${BTC_ACCOUNT_CONF}" --coin "${BTC_COIN}" descriptor export --account payment --output data/descriptor/btc/payment_descriptors.json --format bitcoin-core --include-change)
-	file_descriptor_stored=$(btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --account-config "${BTC_ACCOUNT_CONF}" --coin "${BTC_COIN}" descriptor export --account stored --output data/descriptor/btc/stored_descriptors.json --format bitcoin-core --include-change)
-
-	descriptor_deposit="${file_descriptor_deposit##*exported to }"
-	descriptor_payment="${file_descriptor_payment##*exported to }"
-	descriptor_stored="${file_descriptor_stored##*exported to }"
+	declare -A descriptor_paths
+	for account in deposit payment stored; do
+		output_file="data/descriptor/btc/${account}_descriptors.json"
+		cmd_output=$(btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --account-config "${BTC_ACCOUNT_CONF}" --coin "${BTC_COIN}" descriptor export --account "$account" --output "$output_file" --format bitcoin-core --include-change)
+		descriptor_paths[$account]="${cmd_output##*exported to }"
+	done
 
 	log_substep "Importing descriptors into watch wallet"
-	btc_watch_cmd -c "${BTC_CONFIG_WATCH}" --coin "${BTC_COIN}" import descriptor --file "${descriptor_deposit}" --account deposit
-	btc_watch_cmd -c "${BTC_CONFIG_WATCH}" --coin "${BTC_COIN}" import descriptor --file "${descriptor_payment}" --account payment
-	btc_watch_cmd -c "${BTC_CONFIG_WATCH}" --coin "${BTC_COIN}" import descriptor --file "${descriptor_stored}" --account stored
+	for account in deposit payment stored; do
+		btc_watch_cmd -c "${BTC_CONFIG_WATCH}" --coin "${BTC_COIN}" import descriptor --file "${descriptor_paths[$account]}" --account "$account"
+	done
 
-	first_descriptor=$(jq -r '.[0].desc // empty' "${descriptor_payment}" 2>/dev/null)
+	first_descriptor=$(jq -r '.[0].desc // empty' "${descriptor_paths[payment]}" 2>/dev/null)
 	if [ -z "$first_descriptor" ]; then
 		log_error "Failed to extract descriptor"
 		return 1

--- a/scripts/operation/btc/e2e/e2e-p11-p2tr-tapscript.sh
+++ b/scripts/operation/btc/e2e/e2e-p11-p2tr-tapscript.sh
@@ -121,20 +121,19 @@ tapscript_setup_phase() {
 	log_warn "Tapscript descriptor export is currently a placeholder"
 
 	log_substep "Exporting descriptors from keygen wallet"
-	file_descriptor_deposit=$(btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --account-config "${BTC_ACCOUNT_CONF}" --coin "${BTC_COIN}" descriptor export --account deposit --output data/descriptor/btc/deposit_descriptors.json --format bitcoin-core --include-change)
-	file_descriptor_payment=$(btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --account-config "${BTC_ACCOUNT_CONF}" --coin "${BTC_COIN}" descriptor export --account payment --output data/descriptor/btc/payment_descriptors.json --format bitcoin-core --include-change)
-	file_descriptor_stored=$(btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --account-config "${BTC_ACCOUNT_CONF}" --coin "${BTC_COIN}" descriptor export --account stored --output data/descriptor/btc/stored_descriptors.json --format bitcoin-core --include-change)
-
-	descriptor_deposit="${file_descriptor_deposit##*exported to }"
-	descriptor_payment="${file_descriptor_payment##*exported to }"
-	descriptor_stored="${file_descriptor_stored##*exported to }"
+	declare -A descriptor_paths
+	for account in deposit payment stored; do
+		output_file="data/descriptor/btc/${account}_descriptors.json"
+		cmd_output=$(btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --account-config "${BTC_ACCOUNT_CONF}" --coin "${BTC_COIN}" descriptor export --account "$account" --output "$output_file" --format bitcoin-core --include-change)
+		descriptor_paths[$account]="${cmd_output##*exported to }"
+	done
 
 	log_substep "Importing descriptors into watch wallet"
-	btc_watch_cmd -c "${BTC_CONFIG_WATCH}" --coin "${BTC_COIN}" import descriptor --file "${descriptor_deposit}" --account deposit
-	btc_watch_cmd -c "${BTC_CONFIG_WATCH}" --coin "${BTC_COIN}" import descriptor --file "${descriptor_payment}" --account payment
-	btc_watch_cmd -c "${BTC_CONFIG_WATCH}" --coin "${BTC_COIN}" import descriptor --file "${descriptor_stored}" --account stored
+	for account in deposit payment stored; do
+		btc_watch_cmd -c "${BTC_CONFIG_WATCH}" --coin "${BTC_COIN}" import descriptor --file "${descriptor_paths[$account]}" --account "$account"
+	done
 
-	first_descriptor=$(jq -r '.[0].desc // empty' "${descriptor_payment}" 2>/dev/null)
+	first_descriptor=$(jq -r '.[0].desc // empty' "${descriptor_paths[payment]}" 2>/dev/null)
 	if [ -z "$first_descriptor" ]; then
 		log_error "Failed to extract descriptor"
 		return 1

--- a/scripts/operation/btc/e2e/e2e-p2-p2pkh-2of3.sh
+++ b/scripts/operation/btc/e2e/e2e-p2-p2pkh-2of3.sh
@@ -120,22 +120,21 @@ multisig_setup_phase() {
 	btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --coin "${BTC_COIN}" import fullpubkey --file "${FULLPUBKEY_FILE2}"
 
 	log_substep "Exporting descriptors from keygen wallet"
-	file_descriptor_deposit=$(btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --account-config "${BTC_ACCOUNT_CONF}" --coin "${BTC_COIN}" descriptor export --account deposit --output data/descriptor/btc/deposit_descriptors.json --format bitcoin-core --include-change)
-	file_descriptor_payment=$(btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --account-config "${BTC_ACCOUNT_CONF}" --coin "${BTC_COIN}" descriptor export --account payment --output data/descriptor/btc/payment_descriptors.json --format bitcoin-core --include-change)
-	file_descriptor_stored=$(btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --account-config "${BTC_ACCOUNT_CONF}" --coin "${BTC_COIN}" descriptor export --account stored --output data/descriptor/btc/stored_descriptors.json --format bitcoin-core --include-change)
-
-	descriptor_deposit="${file_descriptor_deposit##*exported to }"
-	descriptor_payment="${file_descriptor_payment##*exported to }"
-	descriptor_stored="${file_descriptor_stored##*exported to }"
+	declare -A descriptor_paths
+	for account in deposit payment stored; do
+		output_file="data/descriptor/btc/${account}_descriptors.json"
+		cmd_output=$(btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --account-config "${BTC_ACCOUNT_CONF}" --coin "${BTC_COIN}" descriptor export --account "$account" --output "$output_file" --format bitcoin-core --include-change)
+		descriptor_paths[$account]="${cmd_output##*exported to }"
+	done
 
 	log_substep "Importing descriptors into watch wallet"
-	btc_watch_cmd -c "${BTC_CONFIG_WATCH}" --coin "${BTC_COIN}" import descriptor --file "${descriptor_deposit}" --account deposit
-	btc_watch_cmd -c "${BTC_CONFIG_WATCH}" --coin "${BTC_COIN}" import descriptor --file "${descriptor_payment}" --account payment
-	btc_watch_cmd -c "${BTC_CONFIG_WATCH}" --coin "${BTC_COIN}" import descriptor --file "${descriptor_stored}" --account stored
+	for account in deposit payment stored; do
+		btc_watch_cmd -c "${BTC_CONFIG_WATCH}" --coin "${BTC_COIN}" import descriptor --file "${descriptor_paths[$account]}" --account "$account"
+	done
 
 	log_info "All descriptors imported successfully"
 
-	first_descriptor=$(jq -r '.[0].desc // empty' "${descriptor_payment}" 2>/dev/null)
+	first_descriptor=$(jq -r '.[0].desc // empty' "${descriptor_paths[payment]}" 2>/dev/null)
 	if [ -z "$first_descriptor" ]; then
 		log_error "Failed to extract descriptor"
 		return 1

--- a/scripts/operation/btc/e2e/e2e-p4-p2sh-p2wsh-2of3.sh
+++ b/scripts/operation/btc/e2e/e2e-p4-p2sh-p2wsh-2of3.sh
@@ -120,22 +120,21 @@ multisig_setup_phase() {
 	btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --coin "${BTC_COIN}" import fullpubkey --file "${FULLPUBKEY_FILE2}"
 
 	log_substep "Exporting descriptors from keygen wallet"
-	file_descriptor_deposit=$(btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --account-config "${BTC_ACCOUNT_CONF}" --coin "${BTC_COIN}" descriptor export --account deposit --output data/descriptor/btc/deposit_descriptors.json --format bitcoin-core --include-change)
-	file_descriptor_payment=$(btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --account-config "${BTC_ACCOUNT_CONF}" --coin "${BTC_COIN}" descriptor export --account payment --output data/descriptor/btc/payment_descriptors.json --format bitcoin-core --include-change)
-	file_descriptor_stored=$(btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --account-config "${BTC_ACCOUNT_CONF}" --coin "${BTC_COIN}" descriptor export --account stored --output data/descriptor/btc/stored_descriptors.json --format bitcoin-core --include-change)
-
-	descriptor_deposit="${file_descriptor_deposit##*exported to }"
-	descriptor_payment="${file_descriptor_payment##*exported to }"
-	descriptor_stored="${file_descriptor_stored##*exported to }"
+	declare -A descriptor_paths
+	for account in deposit payment stored; do
+		output_file="data/descriptor/btc/${account}_descriptors.json"
+		cmd_output=$(btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --account-config "${BTC_ACCOUNT_CONF}" --coin "${BTC_COIN}" descriptor export --account "$account" --output "$output_file" --format bitcoin-core --include-change)
+		descriptor_paths[$account]="${cmd_output##*exported to }"
+	done
 
 	log_substep "Importing descriptors into watch wallet"
-	btc_watch_cmd -c "${BTC_CONFIG_WATCH}" --coin "${BTC_COIN}" import descriptor --file "${descriptor_deposit}" --account deposit
-	btc_watch_cmd -c "${BTC_CONFIG_WATCH}" --coin "${BTC_COIN}" import descriptor --file "${descriptor_payment}" --account payment
-	btc_watch_cmd -c "${BTC_CONFIG_WATCH}" --coin "${BTC_COIN}" import descriptor --file "${descriptor_stored}" --account stored
+	for account in deposit payment stored; do
+		btc_watch_cmd -c "${BTC_CONFIG_WATCH}" --coin "${BTC_COIN}" import descriptor --file "${descriptor_paths[$account]}" --account "$account"
+	done
 
 	log_info "All descriptors imported successfully"
 
-	first_descriptor=$(jq -r '.[0].desc // empty' "${descriptor_payment}" 2>/dev/null)
+	first_descriptor=$(jq -r '.[0].desc // empty' "${descriptor_paths[payment]}" 2>/dev/null)
 	if [ -z "$first_descriptor" ]; then
 		log_error "Failed to extract descriptor"
 		return 1

--- a/scripts/operation/btc/e2e/e2e-p6-p2wsh-2of3.sh
+++ b/scripts/operation/btc/e2e/e2e-p6-p2wsh-2of3.sh
@@ -115,20 +115,19 @@ multisig_setup_phase() {
 	btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --coin "${BTC_COIN}" import fullpubkey --file "${FULLPUBKEY_FILE2}"
 
 	log_substep "Exporting descriptors from keygen wallet"
-	file_descriptor_deposit=$(btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --account-config "${BTC_ACCOUNT_CONF}" --coin "${BTC_COIN}" descriptor export --account deposit --output data/descriptor/btc/deposit_descriptors.json --format bitcoin-core --include-change)
-	file_descriptor_payment=$(btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --account-config "${BTC_ACCOUNT_CONF}" --coin "${BTC_COIN}" descriptor export --account payment --output data/descriptor/btc/payment_descriptors.json --format bitcoin-core --include-change)
-	file_descriptor_stored=$(btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --account-config "${BTC_ACCOUNT_CONF}" --coin "${BTC_COIN}" descriptor export --account stored --output data/descriptor/btc/stored_descriptors.json --format bitcoin-core --include-change)
-
-	descriptor_deposit="${file_descriptor_deposit##*exported to }"
-	descriptor_payment="${file_descriptor_payment##*exported to }"
-	descriptor_stored="${file_descriptor_stored##*exported to }"
+	declare -A descriptor_paths
+	for account in deposit payment stored; do
+		output_file="data/descriptor/btc/${account}_descriptors.json"
+		cmd_output=$(btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --account-config "${BTC_ACCOUNT_CONF}" --coin "${BTC_COIN}" descriptor export --account "$account" --output "$output_file" --format bitcoin-core --include-change)
+		descriptor_paths[$account]="${cmd_output##*exported to }"
+	done
 
 	log_substep "Importing descriptors into watch wallet"
-	btc_watch_cmd -c "${BTC_CONFIG_WATCH}" --coin "${BTC_COIN}" import descriptor --file "${descriptor_deposit}" --account deposit
-	btc_watch_cmd -c "${BTC_CONFIG_WATCH}" --coin "${BTC_COIN}" import descriptor --file "${descriptor_payment}" --account payment
-	btc_watch_cmd -c "${BTC_CONFIG_WATCH}" --coin "${BTC_COIN}" import descriptor --file "${descriptor_stored}" --account stored
+	for account in deposit payment stored; do
+		btc_watch_cmd -c "${BTC_CONFIG_WATCH}" --coin "${BTC_COIN}" import descriptor --file "${descriptor_paths[$account]}" --account "$account"
+	done
 
-	first_descriptor=$(jq -r '.[0].desc // empty' "${descriptor_payment}" 2>/dev/null)
+	first_descriptor=$(jq -r '.[0].desc // empty' "${descriptor_paths[payment]}" 2>/dev/null)
 	if [ -z "$first_descriptor" ]; then
 		log_error "Failed to extract descriptor"
 		return 1

--- a/scripts/operation/btc/e2e/e2e-p7-p2wsh-3of3.sh
+++ b/scripts/operation/btc/e2e/e2e-p7-p2wsh-3of3.sh
@@ -115,20 +115,19 @@ multisig_setup_phase() {
 	btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --coin "${BTC_COIN}" import fullpubkey --file "${FULLPUBKEY_FILE2}"
 
 	log_substep "Exporting descriptors from keygen wallet"
-	file_descriptor_deposit=$(btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --account-config "${BTC_ACCOUNT_CONF}" --coin "${BTC_COIN}" descriptor export --account deposit --output data/descriptor/btc/deposit_descriptors.json --format bitcoin-core --include-change)
-	file_descriptor_payment=$(btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --account-config "${BTC_ACCOUNT_CONF}" --coin "${BTC_COIN}" descriptor export --account payment --output data/descriptor/btc/payment_descriptors.json --format bitcoin-core --include-change)
-	file_descriptor_stored=$(btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --account-config "${BTC_ACCOUNT_CONF}" --coin "${BTC_COIN}" descriptor export --account stored --output data/descriptor/btc/stored_descriptors.json --format bitcoin-core --include-change)
-
-	descriptor_deposit="${file_descriptor_deposit##*exported to }"
-	descriptor_payment="${file_descriptor_payment##*exported to }"
-	descriptor_stored="${file_descriptor_stored##*exported to }"
+	declare -A descriptor_paths
+	for account in deposit payment stored; do
+		output_file="data/descriptor/btc/${account}_descriptors.json"
+		cmd_output=$(btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --account-config "${BTC_ACCOUNT_CONF}" --coin "${BTC_COIN}" descriptor export --account "$account" --output "$output_file" --format bitcoin-core --include-change)
+		descriptor_paths[$account]="${cmd_output##*exported to }"
+	done
 
 	log_substep "Importing descriptors into watch wallet"
-	btc_watch_cmd -c "${BTC_CONFIG_WATCH}" --coin "${BTC_COIN}" import descriptor --file "${descriptor_deposit}" --account deposit
-	btc_watch_cmd -c "${BTC_CONFIG_WATCH}" --coin "${BTC_COIN}" import descriptor --file "${descriptor_payment}" --account payment
-	btc_watch_cmd -c "${BTC_CONFIG_WATCH}" --coin "${BTC_COIN}" import descriptor --file "${descriptor_stored}" --account stored
+	for account in deposit payment stored; do
+		btc_watch_cmd -c "${BTC_CONFIG_WATCH}" --coin "${BTC_COIN}" import descriptor --file "${descriptor_paths[$account]}" --account "$account"
+	done
 
-	first_descriptor=$(jq -r '.[0].desc // empty' "${descriptor_payment}" 2>/dev/null)
+	first_descriptor=$(jq -r '.[0].desc // empty' "${descriptor_paths[payment]}" 2>/dev/null)
 	if [ -z "$first_descriptor" ]; then
 		log_error "Failed to extract descriptor"
 		return 1

--- a/scripts/operation/btc/e2e/e2e-p8-p2sh-p2wsh-3of3.sh
+++ b/scripts/operation/btc/e2e/e2e-p8-p2sh-p2wsh-3of3.sh
@@ -115,20 +115,19 @@ multisig_setup_phase() {
 	btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --coin "${BTC_COIN}" import fullpubkey --file "${FULLPUBKEY_FILE2}"
 
 	log_substep "Exporting descriptors from keygen wallet"
-	file_descriptor_deposit=$(btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --account-config "${BTC_ACCOUNT_CONF}" --coin "${BTC_COIN}" descriptor export --account deposit --output data/descriptor/btc/deposit_descriptors.json --format bitcoin-core --include-change)
-	file_descriptor_payment=$(btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --account-config "${BTC_ACCOUNT_CONF}" --coin "${BTC_COIN}" descriptor export --account payment --output data/descriptor/btc/payment_descriptors.json --format bitcoin-core --include-change)
-	file_descriptor_stored=$(btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --account-config "${BTC_ACCOUNT_CONF}" --coin "${BTC_COIN}" descriptor export --account stored --output data/descriptor/btc/stored_descriptors.json --format bitcoin-core --include-change)
-
-	descriptor_deposit="${file_descriptor_deposit##*exported to }"
-	descriptor_payment="${file_descriptor_payment##*exported to }"
-	descriptor_stored="${file_descriptor_stored##*exported to }"
+	declare -A descriptor_paths
+	for account in deposit payment stored; do
+		output_file="data/descriptor/btc/${account}_descriptors.json"
+		cmd_output=$(btc_keygen_cmd -c "${BTC_CONFIG_KEYGEN}" --account-config "${BTC_ACCOUNT_CONF}" --coin "${BTC_COIN}" descriptor export --account "$account" --output "$output_file" --format bitcoin-core --include-change)
+		descriptor_paths[$account]="${cmd_output##*exported to }"
+	done
 
 	log_substep "Importing descriptors into watch wallet"
-	btc_watch_cmd -c "${BTC_CONFIG_WATCH}" --coin "${BTC_COIN}" import descriptor --file "${descriptor_deposit}" --account deposit
-	btc_watch_cmd -c "${BTC_CONFIG_WATCH}" --coin "${BTC_COIN}" import descriptor --file "${descriptor_payment}" --account payment
-	btc_watch_cmd -c "${BTC_CONFIG_WATCH}" --coin "${BTC_COIN}" import descriptor --file "${descriptor_stored}" --account stored
+	for account in deposit payment stored; do
+		btc_watch_cmd -c "${BTC_CONFIG_WATCH}" --coin "${BTC_COIN}" import descriptor --file "${descriptor_paths[$account]}" --account "$account"
+	done
 
-	first_descriptor=$(jq -r '.[0].desc // empty' "${descriptor_payment}" 2>/dev/null)
+	first_descriptor=$(jq -r '.[0].desc // empty' "${descriptor_paths[payment]}" 2>/dev/null)
 	if [ -z "$first_descriptor" ]; then
 		log_error "Failed to extract descriptor"
 		return 1


### PR DESCRIPTION
## Summary

- Add `--account-config` flag to descriptor export commands in `e2e-p2-p2pkh-2of3.sh` to enable proper multisig (2-of-3) descriptor generation
- Fix `btc_wait_for_balance` to handle verbose mode (`set -x`) by using subshell to prevent shell trace output from contaminating JSON parsing

## Root Cause

The E2E script was missing the `--account-config` flag when calling `descriptor export` commands. Without this flag, the keygen CLI didn't know which accounts were configured for multisig, so it generated **single-sig** `pkh(...)` descriptors instead of **multisig** `sh(sortedmulti(...))` descriptors.

This caused:
1. Wrong address format (single-sig P2PKH instead of P2SH multisig)
2. Balance detection failure (UTXOs sent to wrong address type)
3. Originally reported: `txType is invalid: signed` error during second signing attempt

## Test Plan

- [x] `make btc-e2e-reset P=2` passes successfully
- [x] Address format is correct: `2...` (P2SH regtest format)
- [x] 2-of-3 multisig signing flow works: keygen → sign1 → broadcast
- [x] Shell formatting verified: `make shfmt`

Closes #448