### PR TITLE
chore: add material icon theme for VS Code

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,9 +27,11 @@
         "EditorConfig.EditorConfig",
         "streetsidesoftware.code-spell-checker",
         "ms-azuretools.vscode-docker",
-        "eamodio.gitlens"
+        "eamodio.gitlens",
+        "PKief.material-icon-theme"
       ],
       "settings": {
+        "workbench.iconTheme": "material-icon-theme",
         "editor.formatOnSave": true,
         "files.trimTrailingWhitespace": true,
         "files.insertFinalNewline": true,

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -30,7 +30,8 @@
     "EditorConfig.EditorConfig",
     "streetsidesoftware.code-spell-checker",
     "ms-azuretools.vscode-docker",
-    "eamodio.gitlens"
+    "eamodio.gitlens",
+    "PKief.material-icon-theme"
   ],
   "unwantedRecommendations": []
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
   // General Settings
   // ===================
   "editor.formatOnSave": true,
+  "workbench.iconTheme": "material-icon-theme",
   "files.trimTrailingWhitespace": true,
   "files.insertFinalNewline": true,
   // ===================


### PR DESCRIPTION
## Summary
- Add Material Icon Theme extension for better file icon visibility in VS Code
- Configure devcontainer and VS Code settings

## Changes
- Add `PKief.material-icon-theme` to recommended extensions
- Set `workbench.iconTheme` to `material-icon-theme`

## Test plan
- [x] Devcontainer configuration is valid JSON
- [ ] Extension installs correctly in devcontainer