### PR TITLE
fix(bch): resolve WIF key lookup and file naming issues in signing

### DIFF
--- a/internal/application/usecase/keygen/bch/sign_transaction.go
+++ b/internal/application/usecase/keygen/bch/sign_transaction.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
 
@@ -92,21 +94,24 @@ func (u *signTransactionUseCase) Sign(
 	}
 
 	// Write signed transaction file
-	path := u.txFileRepo.CreateFilePath(actionType, txType, txID, signedCount)
-	// Use .hex extension for BCH
-	if strings.HasSuffix(path, ".psbt") {
-		path = path[:len(path)-5] + ".hex"
-	}
+	// CreateFilePath returns base path without extension: {action}_{txID}_{type}_{count}_
+	// Add timestamp and .hex extension (following WritePSBTFile pattern)
+	// Final format: payment_1_signed_0_1768819476518045000.hex
+	basePath := u.txFileRepo.CreateFilePath(actionType, txType, txID, signedCount)
+	ts := strconv.FormatInt(time.Now().UnixNano(), 10)
+	generatedFileName := basePath + ts + ".hex"
 
-	var generatedFileName string
+	// Write transaction hex to file directly (don't use WriteFile which adds another timestamp)
+	var byteTx []byte
 	if isSigned {
 		// For fully signed transactions, just write the hex
-		generatedFileName, err = u.txFileRepo.WriteFile(path, signedHex)
+		byteTx = []byte(signedHex)
 	} else {
 		// For partially signed, include prevTx metadata for next signer
 		content := u.formatSignedTxContent(signedHex, prevTxs)
-		generatedFileName, err = u.txFileRepo.WriteFile(path, content)
+		byteTx = []byte(content)
 	}
+	err = os.WriteFile(generatedFileName, byteTx, 0o644)
 	if err != nil {
 		return keygenusecase.SignTransactionOutput{}, fmt.Errorf("fail to write signed tx file: %w", err)
 	}
@@ -185,9 +190,13 @@ func (u *signTransactionUseCase) getWIFsForAccount(
 	senderAccount domainAccount.AccountType,
 ) ([]string, error) {
 	// Get keys with various statuses
+	// After export address command, status becomes AddrStatusAddressExported (3)
+	// So we need to query for all relevant statuses
 	statuses := []domainAddress.AddrStatus{
-		domainAddress.AddrStatusHDKeyGenerated,
-		domainAddress.AddrStatusPrivKeyImported,
+		domainAddress.AddrStatusHDKeyGenerated,           // 0
+		domainAddress.AddrStatusPrivKeyImported,          // 1
+		domainAddress.AddrStatusMultisigAddressGenerated, // 2 (for multisig)
+		domainAddress.AddrStatusAddressExported,          // 3 (after export address)
 	}
 
 	wifs := make([]string, 0)
@@ -196,6 +205,7 @@ func (u *signTransactionUseCase) getWIFsForAccount(
 		if err != nil {
 			return nil, fmt.Errorf("fail to get account keys for %s: %w", senderAccount.String(), err)
 		}
+
 		for _, key := range accountKeys {
 			if key.WalletImportFormat != "" {
 				wifs = append(wifs, key.WalletImportFormat)

--- a/scripts/operation/bch/bch_common.sh
+++ b/scripts/operation/bch/bch_common.sh
@@ -872,7 +872,9 @@ bch_generate_test_utxos() {
 # Usage: file_path=$(bch_extract_file_path "$output")
 bch_extract_file_path() {
 	local output="$1"
-	echo "${output##*\[fileName\]: }"
+	# Extract everything after [fileName]: and take only the first line
+	# Output format: [fileName]: /path/to/file.hex\n[signedCount]: 1\n...
+	echo "${output##*\[fileName\]: }" | head -n1
 }
 
 ###############################################################################


### PR DESCRIPTION
## Summary

Fixes the "no WIF keys found for account: payment" error that prevented BCH transaction signing in E2E tests.

## Root Cause

After the `export address` command runs, account key status is updated to `AddrStatusAddressExported` (3), but the signing code was only querying for status 0 (`AddrStatusHDKeyGenerated`) and 1 (`AddrStatusPrivKeyImported`), causing all WIF keys to be missed.

**Database evidence:**
```sql
SELECT coin, account, addr_status FROM btc_account_key WHERE account='payment';
-- Result: bch | payment | 3  (after export address)
```

## Changes

### 1. Query All Relevant Address Statuses
**File:** `internal/application/usecase/keygen/bch/sign_transaction.go:188-209`

Added `AddrStatusMultisigAddressGenerated` (2) and `AddrStatusAddressExported` (3) to the status query list:
```go
statuses := []domainAddress.AddrStatus{
    domainAddress.AddrStatusHDKeyGenerated,           // 0
    domainAddress.AddrStatusPrivKeyImported,          // 1
    domainAddress.AddrStatusMultisigAddressGenerated, // 2
    domainAddress.AddrStatusAddressExported,          // 3 (after export)
}
```

### 2. Fix Signed Transaction File Naming
**File:** `internal/application/usecase/keygen/bch/sign_transaction.go:95-114`

- Use `os.WriteFile` directly with proper timestamp and `.hex` extension
- Format: `payment_1_signed_0_1768819665923280000.hex`
- Avoids double-timestamp issue from `WriteFile` method

### 3. Fix File Path Extraction
**File:** `scripts/operation/bch/bch_common.sh:873-878`

Fixed `bch_extract_file_path` to extract only the filename (first line) from CLI output.

## Test Results

BCH E2E Pattern 1 now successfully:
- ✅ Creates HD keys
- ✅ Imports private keys  
- ✅ Exports addresses
- ✅ Creates unsigned transactions
- ✅ **Signs transactions** (fixed!)
- ⚠️ Sending fails with "min relay fee not met" (tracked in #462)

## Verification

```bash
make build-all && make bch-e2e-reset P=1
```

Transaction signing now works correctly. The relay fee error is a separate issue tracked in #462.

## Related Issues

- Closes #431 (WIF key lookup issue)
- Related to #462 (min relay fee - separate issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
