### PR TITLE
fix(bch): add fee calculation override and DI configuration for BCH (WIP)

### DIFF
--- a/internal/di/container.go
+++ b/internal/di/container.go
@@ -442,8 +442,8 @@ func (c *container) newBTC() apibtc.Bitcoiner {
 			logger.Debug("DI: Creating BitcoinCash instance for BCH")
 			c.btc, err = apibchimpl.NewBitcoinCash(
 				c.newRPCClient(),
-				c.conf.CoinTypeCode,
 				&c.conf.Bitcoin,
+				c.conf.CoinTypeCode,
 			)
 			if err == nil {
 				// Verify the type is correct

--- a/internal/infrastructure/api/btc/bch/bitcoin_cash.go
+++ b/internal/infrastructure/api/btc/bch/bitcoin_cash.go
@@ -35,8 +35,8 @@ type BitcoinCash struct {
 // NewBitcoinCash bitcoin cash instance based on Bitcoin
 func NewBitcoinCash(
 	client *rpcclient.Client,
-	coinTypeCode domainCoin.CoinTypeCode,
 	conf *config.Bitcoin,
+	coinTypeCode domainCoin.CoinTypeCode,
 ) (*BitcoinCash, error) {
 	// bitcoin base
 	bit, err := apibtcimpl.NewBitcoin(client, conf, coinTypeCode)

--- a/internal/infrastructure/api/btc/bch/fee.go
+++ b/internal/infrastructure/api/btc/bch/fee.go
@@ -9,6 +9,13 @@ import (
 	"github.com/hiromaily/go-crypto-wallet/pkg/logger"
 )
 
+const (
+	// minFeeRateSatsPerByte is the minimum fee rate for BCH transactions (1 sat/byte)
+	minFeeRateSatsPerByte = 1
+	// minTxFeeSats is the absolute minimum fee for any BCH transaction (1000 satoshis)
+	minTxFeeSats = 1000
+)
+
 // GetFee overrides BTC GetFee to properly handle BCH fee calculation.
 // BCH differences from BTC:
 //   - No SegWit, so all bytes count equally (no witness discount)
@@ -20,14 +27,9 @@ func (b *BitcoinCash) GetFee(tx *wire.MsgTx, adjustmentFee float64) (btcutil.Amo
 	// BCH regtest and testnets often have unreliable fee estimation
 	// Use a more conservative approach: always start with a safe minimum
 
-	// Calculate minimum fee: 1 sat/byte
+	// Calculate minimum fee: 1 sat/byte using integer arithmetic
 	txSize := tx.SerializeSize()
-	minFeePerByte := 0.00001 // BCH/kB (1 sat/byte)
-	calculatedFee := fmt.Sprintf("%f", minFeePerByte*float64(txSize)/1000)
-	fee, err := b.StrToAmount(calculatedFee)
-	if err != nil {
-		return 0, fmt.Errorf("failed to calculate BCH minimum fee: %w", err)
-	}
+	fee := btcutil.Amount(txSize * minFeeRateSatsPerByte)
 
 	logger.Debug("BCH calculated minimum fee",
 		"tx_size_bytes", txSize,
@@ -60,10 +62,8 @@ func (b *BitcoinCash) GetFee(tx *wire.MsgTx, adjustmentFee float64) (btcutil.Amo
 
 	// BCH minimum: ensure at least 1000 satoshis (0.00001 BCH)
 	// This is a safety net to prevent "min relay fee not met" errors
-	minFee, err := b.FloatToAmount(0.00001) // 1000 satoshis
-	if err != nil {
-		logger.Warn("failed to convert min fee", "error", err)
-	} else if fee < minFee {
+	minFee := btcutil.Amount(minTxFeeSats)
+	if fee < minFee {
 		logger.Debug("increasing fee to BCH minimum",
 			"calculated_fee", fee.ToBTC(),
 			"min_fee", minFee.ToBTC())
@@ -89,7 +89,7 @@ func (b *BitcoinCash) getMinRelayFeeBCH() (btcutil.Amount, error) {
 	if res.RelayFee == 0 {
 		// BCH regtest may return 0 relay fee, use conservative default
 		logger.Debug("BCH relay fee is 0 from getnetworkinfo, using default minimum")
-		return b.FloatToAmount(0.00001) // 1 sat/byte = 0.00001 BCH/kB
+		return btcutil.Amount(minTxFeeSats), nil
 	}
 	fee, err := b.FloatToAmount(res.RelayFee)
 	if err != nil {
@@ -97,10 +97,7 @@ func (b *BitcoinCash) getMinRelayFeeBCH() (btcutil.Amount, error) {
 	}
 
 	// Ensure minimum 1000 satoshis (0.00001 BCH)
-	minFee, err := b.FloatToAmount(0.00001)
-	if err != nil {
-		return fee, nil // Return original fee if conversion fails
-	}
+	minFee := btcutil.Amount(minTxFeeSats)
 	if fee < minFee {
 		return minFee, nil
 	}

--- a/internal/infrastructure/api/btc/connection.go
+++ b/internal/infrastructure/api/btc/connection.go
@@ -26,7 +26,7 @@ func NewBitcoin(
 		return bit, err
 	case domainCoin.BCH:
 		// BCH
-		bitc, err := apibchimpl.NewBitcoinCash(client, coinTypeCode, conf)
+		bitc, err := apibchimpl.NewBitcoinCash(client, conf, coinTypeCode)
 		if err != nil {
 			return nil, fmt.Errorf("fail to call bch.NewBitcoinCash(): %w", err)
 		}


### PR DESCRIPTION
## Summary

Addresses #462 - BCH E2E Pattern 1 test fails with "min relay fee not met" error.

This PR implements BCH-specific fee calculation and DI configuration, but **the E2E test still fails**. This PR is being created to document the investigation and progress so far.

## Changes

### 1. BCH-Specific Fee Calculation (`internal/infrastructure/api/btc/bch/fee.go`)

Created `GetFee()` override for `BitcoinCash` to handle BCH-specific fee requirements:

- **Conservative minimum**: 1 sat/byte (0.00001 BCH/kB) for regtest reliability
- **BCH relay fee validation**: Ensures fee meets network minimum
- **Removes reliance on `estimatesmartfee`**: Which is unreliable in regtest/testnet
- **BCH-specific logging**: For debugging fee calculation

Key differences from BTC:
- No SegWit witness discount (all bytes count equally)
- Uses sat/byte instead of sat/vByte
- More conservative minimums for regtest stability

### 2. DI Container Updates (`internal/di/container.go`)

Modified `newBTC()` to create BCH-specific instances:

```go
if c.conf.CoinTypeCode == domainCoin.BCH {
    c.btc, err = apibchimpl.NewBitcoinCash(...)
} else {
    c.btc, err = apibtcimpl.NewBitcoin(...)
}
```

Added type verification logging to confirm `BitcoinCash` instances are created correctly.

## Investigation Findings

### Root Cause Analysis

Transactions are being created with **0 fee**:

```
Transaction size: 293 bytes
Input:   50.00000000 BCH
Outputs: 49.99550000 + 0.00200000 + 0.00150000 + 0.00100000 = 50.00000000 BCH
Fee:     0.00000000 BCH ❌ (should be at least 0.00001 BCH or 1000 satoshis)
```

### Verification Steps Completed

✅ `BitcoinCash` instances are being created (confirmed via DI logging)  
✅ `GetFee()` method exists with correct signature  
✅ DI container properly instantiates BCH-specific client  
✅ Interface composition includes `RawTransactionCreator` (which has `GetFee`)  
✅ Method signature matches interface exactly  
❌ **BCH `GetFee()` override is NOT being invoked during transaction creation**

### Debugging Evidence

1. **DI Container Logs**: Show `BitcoinCash` instances are created
   ```
   {"msg":"DI: Creating BitcoinCash instance for BCH"}
   {"msg":"DI: Successfully created BitcoinCash instance"}
   ```

2. **No Fee Calculation Logs**: The `logger.Debug("BCH GetFee called", ...)` never appears

3. **Transaction Has Zero Fee**: Decoded transactions confirm 0 fee

4. **No Errors**: Transaction creation succeeds, only broadcast fails

### Hypothesis

The BCH `GetFee()` override is not being invoked due to a Go method resolution issue. Despite the correct implementation, something in the interface composition or type system is causing the **embedded `Bitcoin.GetFee()`** to be called instead of the **`BitcoinCash.GetFee()` override**.

## Current Status

⚠️ **E2E Test Still Fails**

```
Error: fail to send transaction: failed to broadcast transaction: 
fail to call btc.SendRawTransaction(): -26: min relay fee not met (code 66)
```

The implementation is **architecturally correct** but there's a **method dispatch issue** that prevents the override from being invoked.

## Next Steps for Resolution

### Option 1: Explicit Type Assertion (Quick Fix)
Modify the use case to explicitly type-assert to `*BitcoinCash` and call `GetFee()`:

```go
if bchClient, ok := u.bchClient.(*apibchimpl.BitcoinCash); ok {
    fee, err = bchClient.GetFee(msgTx, adjustmentFee)
}
```

### Option 2: Interface Refactoring (Clean Architecture)
Create a dedicated `FeeCalculator` interface in ports and implement it separately for BTC/BCH.

### Option 3: Runtime Debug (Investigation)
Add extensive runtime type checking and method call logging to understand Go's method resolution behavior with embedded structs and interface composition.

## Testing

### Manual Verification Commands

```bash
# Build
make go-lint && make check-build

# Run E2E test
make bch-e2e-reset P=1

# Check transaction
docker exec bch-watch bitcoin-cli -regtest -rpcuser=xyz -rpcpassword=xyz \
  decoderawtransaction $(head -1 data/tx/bch/payment_1_signed_*.hex)
```

### Expected After Fix

- Transaction should have non-zero fee (minimum 1000 satoshis)
- E2E test should complete successfully
- `logger.Debug("BCH GetFee called", ...)` should appear in logs

## Related Issues

- #462 - BCH E2E Pattern 1 fails with "min relay fee not met"  
- #431 - Fixed WIF key lookup and signing (prerequisite, merged)

## Architecture Notes

This follows the BCH override pattern established in the codebase:

```
btc.Bitcoin (embedded in BitcoinCash)
    ├─ GetFee() - BTC implementation
    └─ BitcoinCash.GetFee() - Should override but doesn't
```

BCH-specific behavior should be isolated in `internal/infrastructure/api/btc/bch/` without modifying BTC code.

## Request for Review

This PR documents significant investigation effort. Review feedback needed on:

1. **Method resolution issue**: Why isn't the override being called?
2. **Best approach**: Type assertion vs interface refactoring?
3. **Go internals**: Is this a known gotcha with embedded structs?

---

**Status**: 🚧 Work in Progress - Requires method dispatch fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)