### PR TITLE
feat(xrp): create Makefile for xrpl-grpc-server (Closes #478)

### DIFF
--- a/apps/xrpl-grpc-server/Makefile
+++ b/apps/xrpl-grpc-server/Makefile
@@ -16,29 +16,29 @@ build:
 # Lint code with Biome
 .PHONY: lint
 lint:
-	bun run biome check .
+	bun run lint
 
 # Fix lint issues
 .PHONY: lint-fix
 lint-fix:
-	bun run biome check --write .
+	bun run lint:fix
 
 # Format code with Biome
 .PHONY: format
 format:
-	bun run biome format --write .
+	bun run format
 
 # TypeScript type checking
 .PHONY: typecheck
 typecheck:
-	bun run tsc --noEmit
+	bun run typecheck
 
-# Generate proto files
+# Generate proto files (TypeScript only via root Makefile)
 .PHONY: proto
 proto:
-	bun run buf generate ../../proto/rippleapi
+	bun run proto
 
 # Clean build artifacts
 .PHONY: clean
 clean:
-	rm -rf dist node_modules
+	rm -rf dist node_modules src/gen


### PR DESCRIPTION
## Summary
- Create Makefile for `apps/xrpl-grpc-server` with Bun-based commands
- Add commands for install, dev, build, lint, format, typecheck, proto, and clean

## Changes
- Add `install` - Install dependencies with Bun
- Add `dev` - Development server with hot reload
- Add `build` - Build for production
- Add `lint` / `lint-fix` - Lint code with Biome
- Add `format` - Format code with Biome
- Add `typecheck` - TypeScript type checking
- Add `proto` - Generate proto files
- Add `clean` - Clean build artifacts

## Test plan
- [x] All targets validated with `make -n` (dry run)
- [x] Makefile syntax verified

Closes #478