### PR TITLE
ci(xrp): add Docker support for xrpl-grpc-server

### DIFF
--- a/apps/xrpl-grpc-server/Dockerfile
+++ b/apps/xrpl-grpc-server/Dockerfile
@@ -81,7 +81,7 @@ ENV GRPC_PORT=50051 \
 # Health check - verify the server is responding
 # ConnectRPC servers return 404 for non-service paths, which indicates the server is running
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
-    CMD ["bun", "--eval", "fetch('http://localhost:50051/').then(r => process.exit(r.status === 404 ? 0 : 1)).catch(() => process.exit(1))"]
+    CMD ["bun", "--eval", "fetch('http://localhost:' + (process.env.GRPC_PORT || 50051) + '/').then(r => process.exit(r.status === 404 ? 0 : 1)).catch(() => process.exit(1))"]
 
 # Start the gRPC server
 CMD ["bun", "run", "src/index.ts"]

--- a/compose.xrp.yaml
+++ b/compose.xrp.yaml
@@ -55,9 +55,9 @@ services:
       dockerfile: apps/xrpl-grpc-server/Dockerfile
     container_name: xrpl-grpc-server
     ports:
-      - "${GRPC_PORT:-50051}:50051"
+      - "${GRPC_PORT:-50051}:${GRPC_PORT:-50051}"
     environment:
-      - GRPC_PORT=50051
+      - GRPC_PORT=${GRPC_PORT:-50051}
       - GRPC_HOST=0.0.0.0
       # Connect to local xrp-node via WebSocket (admin port)
       - XRP_WS_URL=ws://xrp-node:6006
@@ -68,7 +68,7 @@ services:
       xrp-node:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "bun", "--eval", "fetch('http://localhost:50051/').then(r=>process.exit(r.status===404?0:1)).catch(()=>process.exit(1))"]
+      test: ["CMD", "bun", "--eval", "fetch('http://localhost:' + (process.env.GRPC_PORT || 50051) + '/').then(r => process.exit(r.status === 404 ? 0 : 1)).catch(() => process.exit(1))"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary

- Add Dockerfile for `xrpl-grpc-server` using Bun 1.3.6 runtime
- Integrate service into `compose.xrp.yaml` with proper networking

## Changes

### Dockerfile (`apps/xrpl-grpc-server/Dockerfile`)
- Multi-stage build for minimal production image
- Non-root user (`xrpl`) for security
- Type checking in builder stage
- Healthcheck to verify server is running
- Pre-generated proto files (Edition 2024 requires local generation)

### Docker Compose (`compose.xrp.yaml`)
- Add `xrpl-grpc-server` service
- Connect to `xrp-node` via WebSocket (`ws://xrp-node:6006`)
- Configure `depends_on` with health condition
- Environment variables: `GRPC_PORT`, `GRPC_HOST`, `XRP_WS_URL`

## Build Instructions

```bash
# Generate proto files first (required for Edition 2024)
make proto-ts

# Build the Docker image
docker compose -f compose.xrp.yaml build xrpl-grpc-server

# Start both services
docker compose -f compose.xrp.yaml up
```

## Test plan

- [x] `docker compose -f compose.xrp.yaml config` validates successfully
- [x] `docker compose -f compose.xrp.yaml build xrpl-grpc-server` builds successfully
- [ ] `docker compose -f compose.xrp.yaml up` starts both services
- [ ] gRPC server responds to health check

Closes #498