### PR TITLE
ci: update golangci-lint to v2.11.4

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -88,7 +88,7 @@ jobs:
         # v9 uses node24 runtime (node20 deprecated by GitHub)
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.10.1
+          version: v2.11.4
           working-directory: ./
           # --fast-only: run only fast linters on PR for quick feedback
           args: --fast-only

--- a/.github/workflows/nightly-lint.yml
+++ b/.github/workflows/nightly-lint.yml
@@ -25,4 +25,4 @@ jobs:
       - name: golangci-lint (strict, full codebase)
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.10.1
+          version: v2.11.4


### PR DESCRIPTION
## Summary

- Update golangci-lint from `v2.10.1` to `v2.11.4` in both `lint-test.yml` and `nightly-lint.yml`

## Problem

The nightly strict-lint CI job was failing with:

```
internal/application/dto/xrp/transaction_file_test.go:306:1: compiler directive unrecognized: //go:fix (gocheckcompilerdirectives)
internal/infrastructure/storage/file/transaction/transaction_json_test.go:582:1: compiler directive unrecognized: //go:fix (gocheckcompilerdirectives)
```

The `//go:fix` directive was not recognized by `gocheckcompilerdirectives` in v2.10.1. v2.11.4 adds support for it.

## Test plan

- [ ] Nightly strict-lint workflow passes

## Related

- Fixes https://github.com/hiromaily/go-crypto-wallet/actions/runs/24704556909/job/72254746647