### PR TITLE
fix: resolve golangci-lint failures in nightly strict-lint CI

### DIFF
--- a/internal/application/dto/xrp/transaction_file_test.go
+++ b/internal/application/dto/xrp/transaction_file_test.go
@@ -300,10 +300,3 @@ func TestXRPTransactionEntry_Validate(t *testing.T) {
 		})
 	}
 }
-
-// Helper function to create string pointer
-//
-//go:fix inline
-func stringPtr(s string) *string {
-	return new(s)
-}

--- a/internal/infrastructure/api/btc/btc/psbt_finalize.go
+++ b/internal/infrastructure/api/btc/btc/psbt_finalize.go
@@ -549,7 +549,8 @@ func orderSignaturesByPubKeyOrder(
 // buildSegWitMultisigFinalScripts builds final scripts for P2SH-P2WSH (SegWit) multisig.
 func buildSegWitMultisigFinalScripts(input *psbt.PInput, sigs [][]byte, inputIndex int) error {
 	// Build witness stack: [OP_0, sig1, sig2, ..., witnessScript]
-	witness := wire.TxWitness{[]byte{}} // OP_0 (required for CHECKMULTISIG bug)
+	witness := make(wire.TxWitness, 0, 1+len(sigs)+1)
+	witness = append(witness, []byte{}) // OP_0 (required for CHECKMULTISIG bug)
 	for _, sig := range sigs {
 		witness = append(witness, sig)
 	}

--- a/internal/infrastructure/storage/file/transaction/transaction_json_test.go
+++ b/internal/infrastructure/storage/file/transaction/transaction_json_test.go
@@ -576,10 +576,3 @@ func TestWriteXRPJSONFilePathTraversal(t *testing.T) {
 		})
 	}
 }
-
-// Helper function to create string pointer
-//
-//go:fix inline
-func stringPtr(s string) *string {
-	return new(s)
-}


### PR DESCRIPTION
- Remove unused stringPtr func and invalid //go:fix inline directive from xrp/transaction_file_test.go and transaction_json_test.go
- Preallocate witness slice in psbt_finalize.go to fix prealloc warning